### PR TITLE
Introducing LowLevelSerialization

### DIFF
--- a/core/src/main/java/org/lionweb/lioncore/java/serialization/LowLevelJsonSerialization.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/serialization/LowLevelJsonSerialization.java
@@ -2,77 +2,18 @@ package org.lionweb.lioncore.java.serialization;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
-import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import org.lionweb.lioncore.java.serialization.data.*;
 
 import javax.annotation.Nullable;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import static org.lionweb.lioncore.java.serialization.SerializationUtils.*;
 
+/**
+ * This class is responsible for handling serialization and unserialization from JSON and the low-level
+ * representation of models composed by SerializationBlock and the related classes.
+ */
 public class LowLevelJsonSerialization {
-    private static final String CONCEPT_LABEL = "concept";
-    private static final String ID_LABEL = "id";
-
-    public LowLevelJsonSerialization() {
-    }
-
-    private void readSerializationFormatVersion(SerializationBlock serializationBlock, JsonObject topLevel) {
-        if (!topLevel.has("serializationFormatVersion")) {
-            throw new IllegalArgumentException("serializationFormatVersion not specified");
-        }
-        String serializationFormatVersion = topLevel.get("serializationFormatVersion").getAsString();
-        serializationBlock.setSerializationFormatVersion(serializationFormatVersion);
-    }
-
-    private void readMetamodels(SerializationBlock serializationBlock, JsonObject topLevel) {
-        if (!topLevel.has("metamodels")) {
-            throw new IllegalArgumentException("metamodels not specified");
-        }
-        if (topLevel.get("metamodels").isJsonArray()) {
-            topLevel.get("metamodels").getAsJsonArray().asList().stream().forEach(element -> {
-                try {
-                    MetamodelKeyVersion metamodelKeyVersion = new MetamodelKeyVersion();
-                    if (element.isJsonObject()) {
-                        JsonObject jsonObject = element.getAsJsonObject();
-                        if (!jsonObject.has("key") || !jsonObject.has("version")) {
-                            throw new IllegalArgumentException("Metamodel should have keys key and version. Found: " + element);
-                        }
-                        metamodelKeyVersion.setKey(jsonObject.get("key").getAsString());
-                        metamodelKeyVersion.setVersion(jsonObject.get("version").getAsString());
-                    } else {
-                        throw new IllegalArgumentException("Metamodel should be an object. Found: " + element);
-                    }
-                    serializationBlock.addMetamodel(metamodelKeyVersion);
-                } catch (Exception e) {
-                    throw new RuntimeException("Issue while unserializing " + element, e);
-                }
-            });
-        } else {
-            throw new IllegalArgumentException("We expected a Json Array, we got instead: " + topLevel.get("metamodels"));
-        }
-    }
-
-    private void readNodes(SerializationBlock serializationBlock, JsonObject topLevel) {
-        if (!topLevel.has("nodes")) {
-            throw new IllegalArgumentException("nodes not specified");
-        }
-        if (topLevel.get("nodes").isJsonArray()) {
-            topLevel.get("nodes").getAsJsonArray().asList().stream().forEach(element -> {
-                try {
-                    SerializedNode node = unserializeNode(element);
-                    serializationBlock.addNode(node);
-                } catch (Exception e) {
-                    throw new RuntimeException("Issue while unserializing " + element, e);
-                }
-            });
-        } else {
-            throw new IllegalArgumentException("We expected a Json Array, we got instead: " + topLevel.get("nodes"));
-        }
-    }
 
     /**
      * This will return a lower-level representation of the information stored in JSON.
@@ -83,13 +24,13 @@ public class LowLevelJsonSerialization {
      * This method follows a "best-effort" approach, try to limit exception thrown and return data whenever is possible,
      * in the measure that it is possible.
      */
-    public SerializationBlock readSerializationBlock(JsonElement jsonElement) {
+    public SerializationBlock unserializeSerializationBlock(JsonElement jsonElement) {
         SerializationBlock serializationBlock = new SerializationBlock();
         if (jsonElement.isJsonObject()) {
             JsonObject topLevel = jsonElement.getAsJsonObject();
             readSerializationFormatVersion(serializationBlock, topLevel);
             readMetamodels(serializationBlock, topLevel);
-            readNodes(serializationBlock, topLevel);
+            unserializeNodes(serializationBlock, topLevel);
             return serializationBlock;
         } else {
             throw new IllegalArgumentException("We expected a Json Object, we got instead: " + jsonElement);
@@ -145,46 +86,68 @@ public class LowLevelJsonSerialization {
         return topLevel;
     }
 
+    private void readSerializationFormatVersion(SerializationBlock serializationBlock, JsonObject topLevel) {
+        if (!topLevel.has("serializationFormatVersion")) {
+            throw new IllegalArgumentException("serializationFormatVersion not specified");
+        }
+        String serializationFormatVersion = topLevel.get("serializationFormatVersion").getAsString();
+        serializationBlock.setSerializationFormatVersion(serializationFormatVersion);
+    }
+
+    private void readMetamodels(SerializationBlock serializationBlock, JsonObject topLevel) {
+        if (!topLevel.has("metamodels")) {
+            throw new IllegalArgumentException("metamodels not specified");
+        }
+        if (topLevel.get("metamodels").isJsonArray()) {
+            topLevel.get("metamodels").getAsJsonArray().asList().stream().forEach(element -> {
+                try {
+                    MetamodelKeyVersion metamodelKeyVersion = new MetamodelKeyVersion();
+                    if (element.isJsonObject()) {
+                        JsonObject jsonObject = element.getAsJsonObject();
+                        if (!jsonObject.has("key") || !jsonObject.has("version")) {
+                            throw new IllegalArgumentException("Metamodel should have keys key and version. Found: "
+                                    + element);
+                        }
+                        metamodelKeyVersion.setKey(jsonObject.get("key").getAsString());
+                        metamodelKeyVersion.setVersion(jsonObject.get("version").getAsString());
+                    } else {
+                        throw new IllegalArgumentException("Metamodel should be an object. Found: " + element);
+                    }
+                    serializationBlock.addMetamodel(metamodelKeyVersion);
+                } catch (Exception e) {
+                    throw new RuntimeException("Issue while unserializing " + element, e);
+                }
+            });
+        } else {
+            throw new IllegalArgumentException("We expected a Json Array, we got instead: "
+                    + topLevel.get("metamodels"));
+        }
+    }
+
+    private void unserializeNodes(SerializationBlock serializationBlock, JsonObject topLevel) {
+        if (!topLevel.has("nodes")) {
+            throw new IllegalArgumentException("nodes not specified");
+        }
+        if (topLevel.get("nodes").isJsonArray()) {
+            topLevel.get("nodes").getAsJsonArray().asList().stream().forEach(element -> {
+                try {
+                    SerializedNode node = unserializeNode(element);
+                    serializationBlock.addNode(node);
+                } catch (Exception e) {
+                    throw new RuntimeException("Issue while unserializing " + element, e);
+                }
+            });
+        } else {
+            throw new IllegalArgumentException("We expected a Json Array, we got instead: " + topLevel.get("nodes"));
+        }
+    }
+
     private JsonElement serializeToJson(MetaPointer metapointer) {
         JsonObject jsonObject = new JsonObject();
         jsonObject.addProperty("metamodel", metapointer.getMetamodel());
         jsonObject.addProperty("version", metapointer.getVersion());
         jsonObject.addProperty("key", metapointer.getKey());
         return jsonObject;
-    }
-
-    private void populateLinks(SerializedNode node, JsonObject data) {
-        if (data.has("children")) {
-            JsonObject children = data.get("children").getAsJsonObject();
-            for (String containmentID : children.keySet()) {
-                JsonArray value = children.get(containmentID).getAsJsonArray();
-                for (JsonElement childEl : value.asList()) {
-                    String childId = childEl.getAsString();
-                    node.addChild(containmentID, childId);
-                }
-            }
-        }
-        if (data.has("references")) {
-            JsonObject references = data.get("references").getAsJsonObject();
-            for (String referenceID : references.keySet()) {
-                JsonArray value = references.get(referenceID).getAsJsonArray();
-                for (JsonElement referredEl : value.asList()) {
-                    try {
-                        JsonObject referenceObj = referredEl.getAsJsonObject();
-                        String referredId = getAsStringOrNull(referenceObj.get("reference"));
-                        String resolveInfo = getAsStringOrNull(referenceObj.get("resolveInfo"));
-                        node.addReferenceValue(referenceID, new SerializedNode.RawReferenceValue(referredId, resolveInfo));
-                    } catch (Exception e) {
-                        throw new RuntimeException("Issue deserializing reference " + referenceID, e);
-                    }
-                }
-            }
-        }
-        if (data.has("parent")) {
-            JsonElement parentValue = data.get("parent");
-            String parentNodeID = parentValue instanceof JsonNull ? null : parentValue.getAsString();
-            node.setParentNodeID(parentNodeID);
-        }
     }
 
     @Nullable
@@ -227,19 +190,6 @@ public class LowLevelJsonSerialization {
         });
 
         return serializedNode;
-    }
-
-    private SerializedNode populateProperties(SerializedNode instance, JsonObject jsonObject) {
-        if (!jsonObject.has("properties") && jsonObject.get("properties").isJsonObject()) {
-            return instance;
-        }
-        JsonObject properties = jsonObject.getAsJsonObject("properties");
-        for (String propertyId : properties.keySet()) {
-            String serializedValue = properties.get(propertyId).getAsString();
-            instance.setPropertyValue(propertyId, serializedValue);
-        }
-
-        return instance;
     }
 
 }

--- a/core/src/main/java/org/lionweb/lioncore/java/serialization/LowLevelJsonSerialization.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/serialization/LowLevelJsonSerialization.java
@@ -1,0 +1,245 @@
+package org.lionweb.lioncore.java.serialization;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import org.lionweb.lioncore.java.serialization.data.*;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.lionweb.lioncore.java.serialization.SerializationUtils.*;
+
+public class LowLevelJsonSerialization {
+    private static final String CONCEPT_LABEL = "concept";
+    private static final String ID_LABEL = "id";
+
+    public LowLevelJsonSerialization() {
+    }
+
+    private void readSerializationFormatVersion(SerializationBlock serializationBlock, JsonObject topLevel) {
+        if (!topLevel.has("serializationFormatVersion")) {
+            throw new IllegalArgumentException("serializationFormatVersion not specified");
+        }
+        String serializationFormatVersion = topLevel.get("serializationFormatVersion").getAsString();
+        serializationBlock.setSerializationFormatVersion(serializationFormatVersion);
+    }
+
+    private void readMetamodels(SerializationBlock serializationBlock, JsonObject topLevel) {
+        if (!topLevel.has("metamodels")) {
+            throw new IllegalArgumentException("metamodels not specified");
+        }
+        if (topLevel.get("metamodels").isJsonArray()) {
+            topLevel.get("metamodels").getAsJsonArray().asList().stream().forEach(element -> {
+                try {
+                    MetamodelKeyVersion metamodelKeyVersion = new MetamodelKeyVersion();
+                    if (element.isJsonObject()) {
+                        JsonObject jsonObject = element.getAsJsonObject();
+                        if (!jsonObject.has("key") || !jsonObject.has("version")) {
+                            throw new IllegalArgumentException("Metamodel should have keys key and version. Found: " + element);
+                        }
+                        metamodelKeyVersion.setKey(jsonObject.get("key").getAsString());
+                        metamodelKeyVersion.setVersion(jsonObject.get("version").getAsString());
+                    } else {
+                        throw new IllegalArgumentException("Metamodel should be an object. Found: " + element);
+                    }
+                    serializationBlock.addMetamodel(metamodelKeyVersion);
+                } catch (Exception e) {
+                    throw new RuntimeException("Issue while unserializing " + element, e);
+                }
+            });
+        } else {
+            throw new IllegalArgumentException("We expected a Json Array, we got instead: " + topLevel.get("metamodels"));
+        }
+    }
+
+    private void readNodes(SerializationBlock serializationBlock, JsonObject topLevel) {
+        if (!topLevel.has("nodes")) {
+            throw new IllegalArgumentException("nodes not specified");
+        }
+        if (topLevel.get("nodes").isJsonArray()) {
+            topLevel.get("nodes").getAsJsonArray().asList().stream().forEach(element -> {
+                try {
+                    SerializedNode node = unserializeNode(element);
+                    serializationBlock.addNode(node);
+                } catch (Exception e) {
+                    throw new RuntimeException("Issue while unserializing " + element, e);
+                }
+            });
+        } else {
+            throw new IllegalArgumentException("We expected a Json Array, we got instead: " + topLevel.get("nodes"));
+        }
+    }
+
+    /**
+     * This will return a lower-level representation of the information stored in JSON.
+     * It is intended to load broken models.
+     * <p>
+     * Possible usages: repair a broken model, extract a metamodel from the model (“model archeology”), etc.
+     * <p>
+     * This method follows a "best-effort" approach, try to limit exception thrown and return data whenever is possible,
+     * in the measure that it is possible.
+     */
+    public SerializationBlock readSerializationBlock(JsonElement jsonElement) {
+        SerializationBlock serializationBlock = new SerializationBlock();
+        if (jsonElement.isJsonObject()) {
+            JsonObject topLevel = jsonElement.getAsJsonObject();
+            readSerializationFormatVersion(serializationBlock, topLevel);
+            readMetamodels(serializationBlock, topLevel);
+            readNodes(serializationBlock, topLevel);
+            return serializationBlock;
+        } else {
+            throw new IllegalArgumentException("We expected a Json Object, we got instead: " + jsonElement);
+        }
+    }
+
+    public JsonElement serializeToJson(SerializationBlock serializationBlock) {
+        JsonObject topLevel = new JsonObject();
+        topLevel.addProperty("serializationFormatVersion", serializationBlock.getSerializationFormatVersion());
+
+        JsonArray metamodels = new JsonArray();
+        topLevel.add("metamodels", metamodels);
+
+        JsonArray nodes = new JsonArray();
+        for (SerializedNode node: serializationBlock.getNodes()) {
+            JsonObject nodeJson = new JsonObject();
+            nodeJson.addProperty("id", node.getID());
+            nodeJson.add("concept", serializeToJson(node.getConcept()));
+
+            JsonArray properties = new JsonArray();
+            for (SerializedPropertyValue propertyValue : node.getProperties()) {
+                JsonObject property = new JsonObject();
+                property.add("property", serializeToJson(propertyValue.getMetaPointer()));
+                property.addProperty("value", propertyValue.getValue());
+                properties.add(property);
+            }
+            nodeJson.add("properties", properties);
+
+            JsonArray children = new JsonArray();
+            for (SerializedContainmentValue childrenValue : node.getContainments()) {
+                JsonObject childrenJ = new JsonObject();
+                childrenJ.add("containment", serializeToJson(childrenValue.getMetaPointer()));
+                childrenJ.add("children", toJsonArray(childrenValue.getValue()));
+                children.add(childrenJ);
+            }
+            nodeJson.add("children", children);
+
+            JsonArray references = new JsonArray();
+            for (SerializedReferenceValue referenceValue : node.getReferences()) {
+                JsonObject reference = new JsonObject();
+                reference.add("reference", serializeToJson(referenceValue.getMetaPointer()));
+                reference.add("targets", toJsonArrayOfReferenceValues(referenceValue.getValue()));
+                references.add(reference);
+            }
+            nodeJson.add("references", references);
+
+            nodeJson.addProperty("parent", node.getParentNodeID());
+
+            nodes.add(nodeJson);
+        }
+        topLevel.add("nodes", nodes);
+
+        return topLevel;
+    }
+
+    private JsonElement serializeToJson(MetaPointer metapointer) {
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("metamodel", metapointer.getMetamodel());
+        jsonObject.addProperty("version", metapointer.getVersion());
+        jsonObject.addProperty("key", metapointer.getKey());
+        return jsonObject;
+    }
+
+    private void populateLinks(SerializedNode node, JsonObject data) {
+        if (data.has("children")) {
+            JsonObject children = data.get("children").getAsJsonObject();
+            for (String containmentID : children.keySet()) {
+                JsonArray value = children.get(containmentID).getAsJsonArray();
+                for (JsonElement childEl : value.asList()) {
+                    String childId = childEl.getAsString();
+                    node.addChild(containmentID, childId);
+                }
+            }
+        }
+        if (data.has("references")) {
+            JsonObject references = data.get("references").getAsJsonObject();
+            for (String referenceID : references.keySet()) {
+                JsonArray value = references.get(referenceID).getAsJsonArray();
+                for (JsonElement referredEl : value.asList()) {
+                    try {
+                        JsonObject referenceObj = referredEl.getAsJsonObject();
+                        String referredId = getAsStringOrNull(referenceObj.get("reference"));
+                        String resolveInfo = getAsStringOrNull(referenceObj.get("resolveInfo"));
+                        node.addReferenceValue(referenceID, new SerializedNode.RawReferenceValue(referredId, resolveInfo));
+                    } catch (Exception e) {
+                        throw new RuntimeException("Issue deserializing reference " + referenceID, e);
+                    }
+                }
+            }
+        }
+        if (data.has("parent")) {
+            JsonElement parentValue = data.get("parent");
+            String parentNodeID = parentValue instanceof JsonNull ? null : parentValue.getAsString();
+            node.setParentNodeID(parentNodeID);
+        }
+    }
+
+    @Nullable
+    private SerializedNode unserializeNode(JsonElement jsonElement) {
+        if (!jsonElement.isJsonObject()) {
+            throw new IllegalArgumentException("Malformed JSON. Object expected but found " + jsonElement);
+        }
+        JsonObject jsonObject = jsonElement.getAsJsonObject();
+
+        SerializedNode serializedNode = new SerializedNode();
+        serializedNode.setID(tryToGetStringProperty(jsonObject, "id"));
+        serializedNode.setConcept(tryToGetMetaPointerProperty(jsonObject, "concept"));
+        serializedNode.setParentNodeID(tryToGetStringProperty(jsonObject, "parent"));
+
+        JsonArray properties = jsonObject.get("properties").getAsJsonArray();
+        properties.forEach(property -> {
+            JsonObject propertyJO = property.getAsJsonObject();
+            serializedNode.addPropertyValue(new SerializedPropertyValue(
+                    tryToGetMetaPointerProperty(propertyJO, "property"),
+                    tryToGetStringProperty(propertyJO, "value")
+            ));
+        });
+
+        JsonArray children = jsonObject.get("children").getAsJsonArray();
+        children.forEach(childrenEntry -> {
+            JsonObject childrenJO = childrenEntry.getAsJsonObject();
+            serializedNode.addContainmentValue(new SerializedContainmentValue(
+                    tryToGetMetaPointerProperty(childrenJO, "containment"),
+                    tryToGetArrayOfStringsProperty(childrenJO, "children")
+            ));
+        });
+
+        JsonArray references = jsonObject.get("references").getAsJsonArray();
+        references.forEach(referenceEntry -> {
+            JsonObject referenceJO = referenceEntry.getAsJsonObject();
+            serializedNode.addReferenceValue(new SerializedReferenceValue(
+                    tryToGetMetaPointerProperty(referenceJO, "reference"),
+                    tryToGetArrayOfReferencesProperty(referenceJO, "targets")
+            ));
+        });
+
+        return serializedNode;
+    }
+
+    private SerializedNode populateProperties(SerializedNode instance, JsonObject jsonObject) {
+        if (!jsonObject.has("properties") && jsonObject.get("properties").isJsonObject()) {
+            return instance;
+        }
+        JsonObject properties = jsonObject.getAsJsonObject("properties");
+        for (String propertyId : properties.keySet()) {
+            String serializedValue = properties.get(propertyId).getAsString();
+            instance.setPropertyValue(propertyId, serializedValue);
+        }
+
+        return instance;
+    }
+
+}

--- a/core/src/main/java/org/lionweb/lioncore/java/serialization/SerializationUtils.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/serialization/SerializationUtils.java
@@ -11,8 +11,16 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/**
+ * Collection of utility methods to simplify serialization and unserialization to JSON.
+ */
 class SerializationUtils {
 
+    private SerializationUtils() {
+        // Prevent instantiation
+    }
+
+    @Nullable
     static String getAsStringOrNull(JsonElement element) {
         if (element == null || element.isJsonNull()) {
             return null;
@@ -42,7 +50,9 @@ class SerializationUtils {
         JsonElement value = jsonObject.get(propertyName);
         if (value.isJsonObject()) {
             JsonObject valueJO = value.getAsJsonObject();
-            return new MetaPointer(tryToGetStringProperty(valueJO,"metamodel"), tryToGetStringProperty(valueJO,"version"), tryToGetStringProperty(valueJO,"key"));
+            return new MetaPointer(tryToGetStringProperty(valueJO,"metamodel"),
+                    tryToGetStringProperty(valueJO,"version"),
+                    tryToGetStringProperty(valueJO,"key"));
         } else {
             return null;
         }
@@ -63,7 +73,8 @@ class SerializationUtils {
     }
 
     @Nullable
-    static List<SerializedReferenceValue.Entry> tryToGetArrayOfReferencesProperty(JsonObject jsonObject, String propertyName) {
+    static List<SerializedReferenceValue.Entry> tryToGetArrayOfReferencesProperty(JsonObject jsonObject,
+                                                                                  String propertyName) {
         if (!jsonObject.has(propertyName)) {
             return null;
         }

--- a/core/src/main/java/org/lionweb/lioncore/java/serialization/SerializationUtils.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/serialization/SerializationUtils.java
@@ -1,0 +1,98 @@
+package org.lionweb.lioncore.java.serialization;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import org.lionweb.lioncore.java.model.ReferenceValue;
+import org.lionweb.lioncore.java.serialization.data.MetaPointer;
+import org.lionweb.lioncore.java.serialization.data.SerializedReferenceValue;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.stream.Collectors;
+
+class SerializationUtils {
+
+    static String getAsStringOrNull(JsonElement element) {
+        if (element == null || element.isJsonNull()) {
+            return null;
+        } else {
+            return element.getAsString();
+        }
+    }
+
+    @Nullable
+    static String tryToGetStringProperty(JsonObject jsonObject, String propertyName) {
+        if (!jsonObject.has(propertyName)) {
+            return null;
+        }
+        JsonElement value = jsonObject.get(propertyName);
+        if (value.isJsonPrimitive() && value.getAsJsonPrimitive().isString()) {
+            return value.getAsJsonPrimitive().getAsString();
+        } else {
+            return null;
+        }
+    }
+
+    @Nullable
+    static MetaPointer tryToGetMetaPointerProperty(JsonObject jsonObject, String propertyName) {
+        if (!jsonObject.has(propertyName)) {
+            return null;
+        }
+        JsonElement value = jsonObject.get(propertyName);
+        if (value.isJsonObject()) {
+            JsonObject valueJO = value.getAsJsonObject();
+            return new MetaPointer(tryToGetStringProperty(valueJO,"metamodel"), tryToGetStringProperty(valueJO,"version"), tryToGetStringProperty(valueJO,"key"));
+        } else {
+            return null;
+        }
+    }
+
+    @Nullable
+    static List<String> tryToGetArrayOfStringsProperty(JsonObject jsonObject, String propertyName) {
+        if (!jsonObject.has(propertyName)) {
+            return null;
+        }
+        JsonElement value = jsonObject.get(propertyName);
+        if (value.isJsonArray()) {
+            JsonArray valueJA = value.getAsJsonArray();
+            return valueJA.asList().stream().map(e -> e.getAsString()).collect(Collectors.toList());
+        } else {
+            return null;
+        }
+    }
+
+    @Nullable
+    static List<SerializedReferenceValue.Entry> tryToGetArrayOfReferencesProperty(JsonObject jsonObject, String propertyName) {
+        if (!jsonObject.has(propertyName)) {
+            return null;
+        }
+        JsonElement value = jsonObject.get(propertyName);
+        if (value.isJsonArray()) {
+            JsonArray valueJA = value.getAsJsonArray();
+            return valueJA.asList().stream().map(e -> new SerializedReferenceValue.Entry(
+                    tryToGetStringProperty(e.getAsJsonObject(), "reference"),
+                    tryToGetStringProperty(e.getAsJsonObject(), "resolveInfo")
+            )).collect(Collectors.toList());
+        } else {
+            return null;
+        }
+    }
+
+    static JsonArray toJsonArray(List<String> stringList) {
+        JsonArray jsonArray = new JsonArray();
+        stringList.forEach(s -> jsonArray.add(s));
+        return jsonArray;
+    }
+
+    static JsonArray toJsonArrayOfReferenceValues(List<SerializedReferenceValue.Entry> entries) {
+        JsonArray jsonArray = new JsonArray();
+        entries.forEach(e -> {
+            JsonObject entryJson = new JsonObject();
+            entryJson.addProperty("resolveInfo", e.getResolveInfo());
+            entryJson.addProperty("reference", e.getReference());
+            jsonArray.add(entryJson);
+        });
+        return jsonArray;
+    }
+}

--- a/core/src/main/java/org/lionweb/lioncore/java/serialization/data/MetaPointer.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/serialization/data/MetaPointer.java
@@ -1,12 +1,15 @@
 package org.lionweb.lioncore.java.serialization.data;
 
-import org.lionweb.lioncore.java.metamodel.Concept;
 import org.lionweb.lioncore.java.metamodel.HasKey;
 import org.lionweb.lioncore.java.metamodel.Metamodel;
 import org.lionweb.lioncore.java.metamodel.MetamodelElement;
 
 import java.util.Objects;
 
+/**
+ * A MetaPointer is the combination of the pair Metamodel & Version with a Key, which identify one element within
+ * that metamodel.
+ */
 public class MetaPointer {
     private String key;
     private String version;

--- a/core/src/main/java/org/lionweb/lioncore/java/serialization/data/MetaPointer.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/serialization/data/MetaPointer.java
@@ -1,0 +1,94 @@
+package org.lionweb.lioncore.java.serialization.data;
+
+import org.lionweb.lioncore.java.metamodel.Concept;
+import org.lionweb.lioncore.java.metamodel.HasKey;
+import org.lionweb.lioncore.java.metamodel.Metamodel;
+import org.lionweb.lioncore.java.metamodel.MetamodelElement;
+
+import java.util.Objects;
+
+public class MetaPointer {
+    private String key;
+    private String version;
+    private String metamodel;
+
+    public MetaPointer(String metamodel, String version, String key) {
+        this.key = key;
+        this.version = version;
+        this.metamodel = metamodel;
+    }
+
+    public MetaPointer() {
+
+    }
+
+    public static MetaPointer from(MetamodelElement<?> metamodelElement) {
+        MetaPointer metaPointer = new MetaPointer();
+        metaPointer.setKey(metamodelElement.getKey());
+        if (metamodelElement.getMetamodel() != null) {
+            metaPointer.setMetamodel(metamodelElement.getMetamodel().getKey());
+            if (metamodelElement.getMetamodel().getVersion() != null) {
+                metaPointer.setVersion(metamodelElement.getMetamodel().getVersion());
+            }
+        }
+        return metaPointer;
+    }
+
+    public static MetaPointer from(HasKey<?> elementWithKey, Metamodel metamodel) {
+        MetaPointer metaPointer = new MetaPointer();
+        metaPointer.setKey(elementWithKey.getKey());
+        if (metamodel != null) {
+            metaPointer.setMetamodel(metamodel.getKey());
+            if (metamodel.getVersion() != null) {
+                metaPointer.setVersion(metamodel.getVersion());
+            }
+        }
+        return metaPointer;
+    }
+
+    public String getMetamodel() {
+        return metamodel;
+    }
+
+    public void setMetamodel(String metamodel) {
+        this.metamodel = metamodel;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof MetaPointer)) return false;
+        MetaPointer that = (MetaPointer) o;
+        return Objects.equals(key, that.key) && Objects.equals(version, that.version) && Objects.equals(metamodel, that.metamodel);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, version, metamodel);
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    @Override
+    public String toString() {
+        return "MetaPointer{" +
+                "key='" + key + '\'' +
+                ", version='" + version + '\'' +
+                ", metamodel='" + metamodel + '\'' +
+                '}';
+    }
+}

--- a/core/src/main/java/org/lionweb/lioncore/java/serialization/data/MetamodelKeyVersion.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/serialization/data/MetamodelKeyVersion.java
@@ -1,0 +1,55 @@
+package org.lionweb.lioncore.java.serialization.data;
+
+import org.lionweb.lioncore.java.metamodel.Metamodel;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+
+public class MetamodelKeyVersion {
+    private String key;
+    private String version;
+
+    public MetamodelKeyVersion() {
+
+    }
+
+    public MetamodelKeyVersion(String key, String version) {
+        this.key = key;
+        this.version = version;
+    }
+
+    public static MetamodelKeyVersion fromMetamodel(@Nonnull Metamodel metamodel) {
+        Objects.requireNonNull(metamodel, "Metamodel parameter should not be null");
+        Objects.requireNonNull(metamodel.getVersion(), "Metamodel version should not be null");
+        return new MetamodelKeyVersion(metamodel.getKey(), metamodel.getVersion());
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof MetamodelKeyVersion)) return false;
+        MetamodelKeyVersion that = (MetamodelKeyVersion) o;
+        return Objects.equals(key, that.key) && Objects.equals(version, that.version);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, version);
+    }
+}

--- a/core/src/main/java/org/lionweb/lioncore/java/serialization/data/MetamodelKeyVersion.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/serialization/data/MetamodelKeyVersion.java
@@ -5,6 +5,9 @@ import org.lionweb.lioncore.java.metamodel.Metamodel;
 import javax.annotation.Nonnull;
 import java.util.Objects;
 
+/**
+ * The pair Metamodel Key and Metamodel Version identify a specific version of a metamodel.
+ */
 public class MetamodelKeyVersion {
     private String key;
     private String version;

--- a/core/src/main/java/org/lionweb/lioncore/java/serialization/data/RawReferenceValue.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/serialization/data/RawReferenceValue.java
@@ -1,0 +1,42 @@
+package org.lionweb.lioncore.java.serialization.data;
+
+import java.util.Objects;
+
+public class RawReferenceValue {
+    public String referredId;
+    public String resolveInfo;
+
+    public String getReferredId() {
+        return referredId;
+    }
+
+    public void setReferredId(String referredId) {
+        this.referredId = referredId;
+    }
+
+    public String getResolveInfo() {
+        return resolveInfo;
+    }
+
+    public void setResolveInfo(String resolveInfo) {
+        this.resolveInfo = resolveInfo;
+    }
+
+    public RawReferenceValue(String referredId, String resolveInfo) {
+        this.referredId = referredId;
+        this.resolveInfo = resolveInfo;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof RawReferenceValue)) return false;
+        RawReferenceValue that = (RawReferenceValue) o;
+        return Objects.equals(referredId, that.referredId) && Objects.equals(resolveInfo, that.resolveInfo);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(referredId, resolveInfo);
+    }
+}

--- a/core/src/main/java/org/lionweb/lioncore/java/serialization/data/SerializationBlock.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/serialization/data/SerializationBlock.java
@@ -1,0 +1,64 @@
+package org.lionweb.lioncore.java.serialization.data;
+
+import javax.annotation.Nonnull;
+import java.util.*;
+
+public class SerializationBlock {
+
+    private Map<String, SerializedNode> nodesByID = new HashMap<>();
+
+    private String serializationFormatVersion;
+    private List<MetamodelKeyVersion> metamodels = new ArrayList<>();
+    private List<SerializedNode> nodes = new ArrayList<>();
+
+    public void setSerializationFormatVersion(String value) {
+        this.serializationFormatVersion = value;
+    }
+
+    public String getSerializationFormatVersion() {
+        return serializationFormatVersion;
+    }
+
+    public List<SerializedNode> getNodes() {
+        return nodes;
+    }
+
+    public void addNode(SerializedNode node) {
+        this.nodesByID.put(node.getID(), node);
+        nodes.add(node);
+    }
+
+    @Nonnull
+    public SerializedNode getNodeByID(String nodeID) {
+        SerializedNode node = this.nodesByID.get(nodeID);
+        if (node == null) {
+            throw new IllegalArgumentException("Cannot find node with ID " + nodeID);
+        }
+        return node;
+    }
+
+    public void addMetamodel(MetamodelKeyVersion metamodel) {
+        this.metamodels.add(metamodel);
+    }
+
+    public Map<String, SerializedNode> getNodesByID() {
+        return nodesByID;
+    }
+
+    public void setNodesByID(Map<String, SerializedNode> nodesByID) {
+        this.nodesByID = nodesByID;
+    }
+
+    public List<MetamodelKeyVersion> getMetamodels() {
+        return metamodels;
+    }
+
+    @Override
+    public String toString() {
+        return "SerializationBlock{" +
+                ", serializationFormatVersion='" + serializationFormatVersion + '\'' +
+                ", metamodels=" + metamodels +
+                ", nodes=" + nodes +
+                '}';
+    }
+}

--- a/core/src/main/java/org/lionweb/lioncore/java/serialization/data/SerializedChunk.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/serialization/data/SerializedChunk.java
@@ -3,7 +3,12 @@ package org.lionweb.lioncore.java.serialization.data;
 import javax.annotation.Nonnull;
 import java.util.*;
 
-public class SerializationBlock {
+/**
+ * This represents a chunk of nodes which have been serialized. The serialization could be inconsistent.
+ * This is a low-level representation, intended to represent broken chunks or as an intermediate step during
+ * serialization or unserialization.
+ */
+public class SerializedChunk {
 
     private Map<String, SerializedNode> nodesByID = new HashMap<>();
 
@@ -45,10 +50,6 @@ public class SerializationBlock {
         return nodesByID;
     }
 
-    public void setNodesByID(Map<String, SerializedNode> nodesByID) {
-        this.nodesByID = nodesByID;
-    }
-
     public List<MetamodelKeyVersion> getMetamodels() {
         return metamodels;
     }
@@ -60,5 +61,18 @@ public class SerializationBlock {
                 ", metamodels=" + metamodels +
                 ", nodes=" + nodes +
                 '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof SerializedChunk)) return false;
+        SerializedChunk that = (SerializedChunk) o;
+        return serializationFormatVersion.equals(that.serializationFormatVersion) && metamodels.equals(that.metamodels) && nodes.equals(that.nodes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(serializationFormatVersion, metamodels, nodes);
     }
 }

--- a/core/src/main/java/org/lionweb/lioncore/java/serialization/data/SerializedContainmentValue.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/serialization/data/SerializedContainmentValue.java
@@ -1,0 +1,55 @@
+package org.lionweb.lioncore.java.serialization.data;
+
+import java.util.List;
+import java.util.Objects;
+
+public class SerializedContainmentValue {
+    private MetaPointer metaPointer;
+    private List<String> value;
+
+    public SerializedContainmentValue() {
+
+    }
+
+    public SerializedContainmentValue(MetaPointer metaPointer, List<String> value) {
+        this.metaPointer = metaPointer;
+        this.value = value;
+    }
+
+    public MetaPointer getMetaPointer() {
+        return metaPointer;
+    }
+
+    public void setMetaPointer(MetaPointer metaPointer) {
+        this.metaPointer = metaPointer;
+    }
+
+    public List<String> getValue() {
+        return value;
+    }
+
+    public void setValue(List<String> value) {
+        this.value = value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof SerializedContainmentValue)) return false;
+        SerializedContainmentValue that = (SerializedContainmentValue) o;
+        return Objects.equals(metaPointer, that.metaPointer) && Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(metaPointer, value);
+    }
+
+    @Override
+    public String toString() {
+        return "SerializedContainmentValue{" +
+                "metaPointer=" + metaPointer +
+                ", value=" + value +
+                '}';
+    }
+}

--- a/core/src/main/java/org/lionweb/lioncore/java/serialization/data/SerializedContainmentValue.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/serialization/data/SerializedContainmentValue.java
@@ -3,6 +3,9 @@ package org.lionweb.lioncore.java.serialization.data;
 import java.util.List;
 import java.util.Objects;
 
+/**
+ * This represents the serialization of the values of a containment link in a Node.
+ */
 public class SerializedContainmentValue {
     private MetaPointer metaPointer;
     private List<String> value;
@@ -24,10 +27,16 @@ public class SerializedContainmentValue {
         this.metaPointer = metaPointer;
     }
 
+    /**
+     * This returns the list of Node-IDs contained.
+     */
     public List<String> getValue() {
         return value;
     }
 
+    /**
+     * This expects the list of Node-IDs contained.
+     */
     public void setValue(List<String> value) {
         this.value = value;
     }

--- a/core/src/main/java/org/lionweb/lioncore/java/serialization/data/SerializedNode.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/serialization/data/SerializedNode.java
@@ -1,9 +1,9 @@
 package org.lionweb.lioncore.java.serialization.data;
 
-import org.checkerframework.checker.units.qual.A;
-
 import javax.annotation.Nullable;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * Lower level representation of Node which is used to load broken nodes during serialization.
@@ -16,6 +16,15 @@ public class SerializedNode {
     private List<SerializedPropertyValue> properties = new ArrayList<>();
     private List<SerializedContainmentValue> containments = new ArrayList<>();
     private List<SerializedReferenceValue> references = new ArrayList<>();
+
+    public SerializedNode() {
+
+    }
+
+    public SerializedNode(String id, MetaPointer concept) {
+        setID(id);
+        setConcept(concept);
+    }
 
     public String getParentNodeID() {
         return parentNodeID;
@@ -31,7 +40,7 @@ public class SerializedNode {
 
     public List<String> getChildren() {
         List<String> children = new ArrayList<>();
-        this.containments.stream().forEach(c -> children.addAll(c.getValue()));
+        this.containments.forEach(c -> children.addAll(c.getValue()));
         return children;
     }
 
@@ -55,54 +64,6 @@ public class SerializedNode {
         this.references.add(referenceValue);
     }
 
-    public static class RawReferenceValue {
-        public String referredId;
-        public String resolveInfo;
-
-        public String getReferredId() {
-            return referredId;
-        }
-
-        public void setReferredId(String referredId) {
-            this.referredId = referredId;
-        }
-
-        public String getResolveInfo() {
-            return resolveInfo;
-        }
-
-        public void setResolveInfo(String resolveInfo) {
-            this.resolveInfo = resolveInfo;
-        }
-
-        public RawReferenceValue(String referredId, String resolveInfo) {
-            this.referredId = referredId;
-            this.resolveInfo = resolveInfo;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof RawReferenceValue)) return false;
-            RawReferenceValue that = (RawReferenceValue) o;
-            return Objects.equals(referredId, that.referredId) && Objects.equals(resolveInfo, that.resolveInfo);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(referredId, resolveInfo);
-        }
-    }
-
-    public SerializedNode() {
-
-    }
-
-    public SerializedNode(String id, MetaPointer concept) {
-        setID(id);
-        setConcept(concept);
-    }
-
     public MetaPointer getConcept() {
         return concept;
     }
@@ -116,24 +77,20 @@ public class SerializedNode {
         return id;
     }
 
-
     public void setID(String id) {
         this.id = id;
     }
 
-    public void setPropertyValue(String propertyId, String serializedValue) {
-        //this.propertyValues.put(propertyId, serializedValue);
-        throw new UnsupportedOperationException();
+    public void setPropertyValue(MetaPointer property, String serializedValue) {
+        this.properties.add(new SerializedPropertyValue(property, serializedValue));
     }
 
-    public void addChild(String containmentID, String childId) {
-        //this.containmentsValues.computeIfAbsent(containmentID, s -> new ArrayList<>()).add(childId);
-        throw new UnsupportedOperationException();
+    public void addChildren(MetaPointer containment, List<String> childrenIds) {
+        this.containments.add(new SerializedContainmentValue(containment, childrenIds));
     }
 
-    public void addReferenceValue(String referenceID, RawReferenceValue referenceValue) {
-        //this.referencesValues.computeIfAbsent(referenceID, s -> new ArrayList<>()).add(referenceValue);
-        throw new UnsupportedOperationException();
+    public void addReferenceValue(MetaPointer reference, List<SerializedReferenceValue.Entry> referenceValues) {
+        this.references.add(new SerializedReferenceValue(reference, referenceValues));
     }
 
     @Nullable

--- a/core/src/main/java/org/lionweb/lioncore/java/serialization/data/SerializedNode.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/serialization/data/SerializedNode.java
@@ -1,0 +1,183 @@
+package org.lionweb.lioncore.java.serialization.data;
+
+import org.checkerframework.checker.units.qual.A;
+
+import javax.annotation.Nullable;
+import java.util.*;
+
+/**
+ * Lower level representation of Node which is used to load broken nodes during serialization.
+ */
+public class SerializedNode {
+    private String id;
+    private MetaPointer concept;
+    private String parentNodeID;
+
+    private List<SerializedPropertyValue> properties = new ArrayList<>();
+    private List<SerializedContainmentValue> containments = new ArrayList<>();
+    private List<SerializedReferenceValue> references = new ArrayList<>();
+
+    public String getParentNodeID() {
+        return parentNodeID;
+    }
+
+    public void setParentNodeID(String parentNodeID) {
+        this.parentNodeID = parentNodeID;
+    }
+
+    public List<SerializedContainmentValue> getContainments() {
+        return this.containments;
+    }
+
+    public List<String> getChildren() {
+        List<String> children = new ArrayList<>();
+        this.containments.stream().forEach(c -> children.addAll(c.getValue()));
+        return children;
+    }
+
+    public List<SerializedReferenceValue> getReferences() {
+        return this.references;
+    }
+
+    public List<SerializedPropertyValue> getProperties() {
+        return properties;
+    }
+
+    public void addPropertyValue(SerializedPropertyValue propertyValue) {
+        this.properties.add(propertyValue);
+    }
+
+    public void addContainmentValue(SerializedContainmentValue containmentValue) {
+        this.containments.add(containmentValue);
+    }
+
+    public void addReferenceValue(SerializedReferenceValue referenceValue) {
+        this.references.add(referenceValue);
+    }
+
+    public static class RawReferenceValue {
+        public String referredId;
+        public String resolveInfo;
+
+        public String getReferredId() {
+            return referredId;
+        }
+
+        public void setReferredId(String referredId) {
+            this.referredId = referredId;
+        }
+
+        public String getResolveInfo() {
+            return resolveInfo;
+        }
+
+        public void setResolveInfo(String resolveInfo) {
+            this.resolveInfo = resolveInfo;
+        }
+
+        public RawReferenceValue(String referredId, String resolveInfo) {
+            this.referredId = referredId;
+            this.resolveInfo = resolveInfo;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof RawReferenceValue)) return false;
+            RawReferenceValue that = (RawReferenceValue) o;
+            return Objects.equals(referredId, that.referredId) && Objects.equals(resolveInfo, that.resolveInfo);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(referredId, resolveInfo);
+        }
+    }
+
+    public SerializedNode() {
+
+    }
+
+    public SerializedNode(String id, MetaPointer concept) {
+        setID(id);
+        setConcept(concept);
+    }
+
+    public MetaPointer getConcept() {
+        return concept;
+    }
+
+    public void setConcept(MetaPointer concept) {
+        this.concept = concept;
+    }
+
+    @Nullable
+    public String getID() {
+        return id;
+    }
+
+
+    public void setID(String id) {
+        this.id = id;
+    }
+
+    public void setPropertyValue(String propertyId, String serializedValue) {
+        //this.propertyValues.put(propertyId, serializedValue);
+        throw new UnsupportedOperationException();
+    }
+
+    public void addChild(String containmentID, String childId) {
+        //this.containmentsValues.computeIfAbsent(containmentID, s -> new ArrayList<>()).add(childId);
+        throw new UnsupportedOperationException();
+    }
+
+    public void addReferenceValue(String referenceID, RawReferenceValue referenceValue) {
+        //this.referencesValues.computeIfAbsent(referenceID, s -> new ArrayList<>()).add(referenceValue);
+        throw new UnsupportedOperationException();
+    }
+
+    @Nullable
+    public String getPropertyValue(String propertyKey) {
+        for (SerializedPropertyValue pv: this.getProperties()) {
+            if (pv.getMetaPointer().getKey().equals(propertyKey)) {
+                return pv.getValue();
+            }
+        }
+        return null;
+    }
+
+    @Nullable
+    public List<SerializedReferenceValue.Entry> getReferenceValues(String referenceKey) {
+        for (SerializedReferenceValue rv: this.getReferences()) {
+            if (rv.getMetaPointer().getKey().equals(referenceKey)) {
+                return rv.getValue();
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof SerializedNode)) return false;
+        SerializedNode that = (SerializedNode) o;
+        return Objects.equals(id, that.id) && Objects.equals(concept, that.concept) && Objects.equals(parentNodeID, that.parentNodeID) && Objects.equals(properties, that.properties) && Objects.equals(containments, that.containments) && Objects.equals(references, that.references);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, concept, parentNodeID, properties, containments, references);
+    }
+
+    @Override
+    public String toString() {
+        return "SerializedNode{" +
+                "id='" + id + '\'' +
+                ", concept=" + concept +
+                ", parentNodeID='" + parentNodeID + '\'' +
+                ", properties=" + properties +
+                ", containments=" + containments +
+                ", references=" + references +
+                '}';
+    }
+}

--- a/core/src/main/java/org/lionweb/lioncore/java/serialization/data/SerializedPropertyValue.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/serialization/data/SerializedPropertyValue.java
@@ -1,0 +1,54 @@
+package org.lionweb.lioncore.java.serialization.data;
+
+import java.util.Objects;
+
+public class SerializedPropertyValue {
+    private MetaPointer metaPointer;
+    private String value;
+
+    public SerializedPropertyValue() {
+
+    }
+
+    public SerializedPropertyValue(MetaPointer metaPointer, String value) {
+        this.metaPointer = metaPointer;
+        this.value = value;
+    }
+
+    public MetaPointer getMetaPointer() {
+        return metaPointer;
+    }
+
+    public void setMetaPointer(MetaPointer metaPointer) {
+        this.metaPointer = metaPointer;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return "SerializedPropertyValue{" +
+                "metaPointer=" + metaPointer +
+                ", value='" + value + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof SerializedPropertyValue)) return false;
+        SerializedPropertyValue that = (SerializedPropertyValue) o;
+        return Objects.equals(metaPointer, that.metaPointer) && Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(metaPointer, value);
+    }
+}

--- a/core/src/main/java/org/lionweb/lioncore/java/serialization/data/SerializedPropertyValue.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/serialization/data/SerializedPropertyValue.java
@@ -2,6 +2,9 @@ package org.lionweb.lioncore.java.serialization.data;
 
 import java.util.Objects;
 
+/**
+ * This represents the serialization of the value of a property in a Node.
+ */
 public class SerializedPropertyValue {
     private MetaPointer metaPointer;
     private String value;

--- a/core/src/main/java/org/lionweb/lioncore/java/serialization/data/SerializedReferenceValue.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/serialization/data/SerializedReferenceValue.java
@@ -1,0 +1,108 @@
+package org.lionweb.lioncore.java.serialization.data;
+
+import org.lionweb.lioncore.java.model.ReferenceValue;
+
+import java.util.List;
+import java.util.Objects;
+
+public class SerializedReferenceValue {
+
+    public static class Entry {
+        private String resolveInfo;
+        private String reference;
+
+        public Entry() {
+        }
+
+        public Entry(String reference, String resolveInfo) {
+            this.resolveInfo = resolveInfo;
+            this.reference = reference;
+        }
+
+        public String getResolveInfo() {
+            return resolveInfo;
+        }
+
+        public void setResolveInfo(String resolveInfo) {
+            this.resolveInfo = resolveInfo;
+        }
+
+        public String getReference() {
+            return reference;
+        }
+
+        public void setReference(String reference) {
+            this.reference = reference;
+        }
+
+        @Override
+        public String toString() {
+            return "Entry{" +
+                    "resolveInfo='" + resolveInfo + '\'' +
+                    ", reference='" + reference + '\'' +
+                    '}';
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof Entry)) return false;
+            Entry entry = (Entry) o;
+            return Objects.equals(resolveInfo, entry.resolveInfo) && Objects.equals(reference, entry.reference);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(resolveInfo, reference);
+        }
+    }
+
+    private MetaPointer metaPointer;
+    private List<Entry> value;
+
+    public SerializedReferenceValue() {
+
+    }
+
+    public SerializedReferenceValue(MetaPointer metaPointer, List<Entry> value) {
+        this.metaPointer = metaPointer;
+        this.value = value;
+    }
+
+    public MetaPointer getMetaPointer() {
+        return metaPointer;
+    }
+
+    public void setMetaPointer(MetaPointer metaPointer) {
+        this.metaPointer = metaPointer;
+    }
+
+    public List<Entry> getValue() {
+        return value;
+    }
+
+    public void setValue(List<Entry> value) {
+        this.value = value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof SerializedReferenceValue)) return false;
+        SerializedReferenceValue that = (SerializedReferenceValue) o;
+        return Objects.equals(metaPointer, that.metaPointer) && Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(metaPointer, value);
+    }
+
+    @Override
+    public String toString() {
+        return "SerializedReferenceValue{" +
+                "metaPointer=" + metaPointer +
+                ", value=" + value +
+                '}';
+    }
+}

--- a/core/src/main/java/org/lionweb/lioncore/java/serialization/data/SerializedReferenceValue.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/serialization/data/SerializedReferenceValue.java
@@ -1,10 +1,11 @@
 package org.lionweb.lioncore.java.serialization.data;
 
-import org.lionweb.lioncore.java.model.ReferenceValue;
-
 import java.util.List;
 import java.util.Objects;
 
+/**
+ * This represents the serialization of the values of a reference link in a Node.
+ */
 public class SerializedReferenceValue {
 
     public static class Entry {

--- a/core/src/test/java/org/lionweb/lioncore/java/serialization/LowLevelJsonSerializationTest.java
+++ b/core/src/test/java/org/lionweb/lioncore/java/serialization/LowLevelJsonSerializationTest.java
@@ -50,7 +50,7 @@ public class LowLevelJsonSerializationTest {
     }
 
     @Test
-    public void unserializeLibraryMetamodel() {
+    public void unserializeLibraryMetamodelToSerializedNodes() {
         InputStream inputStream = this.getClass().getResourceAsStream("/serialization/library-metamodel.json");
         JsonElement jsonElement = JsonParser.parseReader(new InputStreamReader(inputStream));
         LowLevelJsonSerialization jsonSerialization = new LowLevelJsonSerialization();
@@ -64,8 +64,22 @@ public class LowLevelJsonSerializationTest {
     }
 
     @Test
-    public void reserializeLibrary() {
-        InputStream inputStream = this.getClass().getResourceAsStream("/serialization/library-metamodel.json");
+    public void reserializeLibraryMetamodel() {
+        assertTheFileIsReserializedFromLowLevelCorrectly("/serialization/library-metamodel.json");
+    }
+
+    @Test
+    public void reserializeBobsLibrary() {
+        assertTheFileIsReserializedFromLowLevelCorrectly("/serialization/bobslibrary.json");
+    }
+
+    @Test
+    public void reserializeLanguageEngineeringLibrary() {
+        assertTheFileIsReserializedFromLowLevelCorrectly("/serialization/langeng-library.json");
+    }
+
+    private void assertTheFileIsReserializedFromLowLevelCorrectly(String filePath) {
+        InputStream inputStream = this.getClass().getResourceAsStream(filePath);
         JsonElement jsonElement = JsonParser.parseReader(new InputStreamReader(inputStream));
         LowLevelJsonSerialization jsonSerialization = new LowLevelJsonSerialization();
         SerializedChunk serializedChunk = jsonSerialization.unserializeSerializationBlock(jsonElement);

--- a/core/src/test/java/org/lionweb/lioncore/java/serialization/LowLevelJsonSerializationTest.java
+++ b/core/src/test/java/org/lionweb/lioncore/java/serialization/LowLevelJsonSerializationTest.java
@@ -3,7 +3,6 @@ package org.lionweb.lioncore.java.serialization;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import org.junit.Test;
-import org.lionweb.lioncore.java.self.LionCore;
 import org.lionweb.lioncore.java.serialization.data.MetaPointer;
 import org.lionweb.lioncore.java.serialization.data.SerializationBlock;
 import org.lionweb.lioncore.java.serialization.data.SerializedNode;
@@ -25,7 +24,7 @@ public class LowLevelJsonSerializationTest {
         InputStream inputStream = this.getClass().getResourceAsStream("/serialization/lioncore.json");
         JsonElement jsonElement = JsonParser.parseReader(new InputStreamReader(inputStream));
         LowLevelJsonSerialization jsonSerialization = new LowLevelJsonSerialization();
-        SerializationBlock serializationBlock = jsonSerialization.readSerializationBlock(jsonElement);
+        SerializationBlock serializationBlock = jsonSerialization.unserializeSerializationBlock(jsonElement);
         List<SerializedNode> unserializedSerializedNodeData = serializationBlock.getNodes();
 
         SerializedNode lioncore = unserializedSerializedNodeData.get(0);
@@ -55,7 +54,7 @@ public class LowLevelJsonSerializationTest {
         InputStream inputStream = this.getClass().getResourceAsStream("/serialization/library-metamodel.json");
         JsonElement jsonElement = JsonParser.parseReader(new InputStreamReader(inputStream));
         LowLevelJsonSerialization jsonSerialization = new LowLevelJsonSerialization();
-        SerializationBlock serializationBlock = jsonSerialization.readSerializationBlock(jsonElement);
+        SerializationBlock serializationBlock = jsonSerialization.unserializeSerializationBlock(jsonElement);
         SerializedNode book = serializationBlock.getNodeByID("library-Book");
         assertEquals("Book", book.getPropertyValue("LIonCore_M3_NamespacedEntity_simpleName"));
 
@@ -69,7 +68,7 @@ public class LowLevelJsonSerializationTest {
         InputStream inputStream = this.getClass().getResourceAsStream("/serialization/library-metamodel.json");
         JsonElement jsonElement = JsonParser.parseReader(new InputStreamReader(inputStream));
         LowLevelJsonSerialization jsonSerialization = new LowLevelJsonSerialization();
-        SerializationBlock serializationBlock = jsonSerialization.readSerializationBlock(jsonElement);
+        SerializationBlock serializationBlock = jsonSerialization.unserializeSerializationBlock(jsonElement);
         JsonElement reserialized = jsonSerialization.serializeToJson(serializationBlock);
         assertEquivalentLionWebJson(jsonElement.getAsJsonObject(), reserialized.getAsJsonObject());
     }

--- a/core/src/test/java/org/lionweb/lioncore/java/serialization/LowLevelJsonSerializationTest.java
+++ b/core/src/test/java/org/lionweb/lioncore/java/serialization/LowLevelJsonSerializationTest.java
@@ -1,0 +1,77 @@
+package org.lionweb.lioncore.java.serialization;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import org.junit.Test;
+import org.lionweb.lioncore.java.self.LionCore;
+import org.lionweb.lioncore.java.serialization.data.MetaPointer;
+import org.lionweb.lioncore.java.serialization.data.SerializationBlock;
+import org.lionweb.lioncore.java.serialization.data.SerializedNode;
+import org.lionweb.lioncore.java.serialization.data.SerializedReferenceValue;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.lionweb.lioncore.java.serialization.SerializedJsonComparisonUtils.assertEquivalentLionWebJson;
+
+public class LowLevelJsonSerializationTest {
+
+    @Test
+    public void unserializeLionCoreToSerializedNodes() {
+        InputStream inputStream = this.getClass().getResourceAsStream("/serialization/lioncore.json");
+        JsonElement jsonElement = JsonParser.parseReader(new InputStreamReader(inputStream));
+        LowLevelJsonSerialization jsonSerialization = new LowLevelJsonSerialization();
+        SerializationBlock serializationBlock = jsonSerialization.readSerializationBlock(jsonElement);
+        List<SerializedNode> unserializedSerializedNodeData = serializationBlock.getNodes();
+
+        SerializedNode lioncore = unserializedSerializedNodeData.get(0);
+        assertEquals(new MetaPointer("LIonCore_M3", "1", "LIonCore_M3_Metamodel"), lioncore.getConcept());
+        assertEquals("LIonCore_M3", lioncore.getID());
+        assertEquals("LIonCore.M3", lioncore.getPropertyValue("LIonCore_M3_Metamodel_name"));
+        assertEquals(17, lioncore.getChildren().size());
+        assertEquals(null, lioncore.getParentNodeID());
+
+        SerializedNode namespacedEntity = unserializedSerializedNodeData.stream().filter(e -> e.getID().equals("LIonCore_M3_NamespacedEntity")).findFirst().get();
+        assertEquals(new MetaPointer("LIonCore_M3", "1", "LIonCore_M3_Concept"), namespacedEntity.getConcept());
+        assertEquals("LIonCore_M3_NamespacedEntity", namespacedEntity.getID());
+        assertEquals("true", namespacedEntity.getPropertyValue("LIonCore_M3_Concept_abstract"));
+        assertEquals("NamespacedEntity", namespacedEntity.getPropertyValue("LIonCore_M3_NamespacedEntity_simpleName"));
+        assertEquals(2, namespacedEntity.getChildren().size());
+        assertEquals(lioncore.getID(), namespacedEntity.getParentNodeID());
+
+        SerializedNode simpleName = unserializedSerializedNodeData.stream().filter(e -> e.getID().equals("LIonCore_M3_NamespacedEntity_simpleName")).findFirst().get();
+        assertEquals(new MetaPointer("LIonCore_M3", "1", "LIonCore_M3_Property"), simpleName.getConcept());
+        assertEquals("simpleName", simpleName.getPropertyValue("LIonCore_M3_NamespacedEntity_simpleName"));
+        assertEquals("LIonCore_M3_NamespacedEntity", simpleName.getParentNodeID());
+        assertEquals(Arrays.asList(new SerializedReferenceValue.Entry("LIonCore_M3_String", "String")), simpleName.getReferenceValues("LIonCore_M3_Property_type"));
+    }
+
+    @Test
+    public void unserializeLibraryMetamodel() {
+        InputStream inputStream = this.getClass().getResourceAsStream("/serialization/library-metamodel.json");
+        JsonElement jsonElement = JsonParser.parseReader(new InputStreamReader(inputStream));
+        LowLevelJsonSerialization jsonSerialization = new LowLevelJsonSerialization();
+        SerializationBlock serializationBlock = jsonSerialization.readSerializationBlock(jsonElement);
+        SerializedNode book = serializationBlock.getNodeByID("library-Book");
+        assertEquals("Book", book.getPropertyValue("LIonCore_M3_NamespacedEntity_simpleName"));
+
+        SerializedNode guidedBookWriter = serializationBlock.getNodeByID("library-GuideBookWriter");
+        assertEquals("GuideBookWriter", guidedBookWriter.getPropertyValue("LIonCore_M3_NamespacedEntity_simpleName"));
+        assertEquals(Arrays.asList(new SerializedReferenceValue.Entry("library-Writer", "Writer")), guidedBookWriter.getReferenceValues("LIonCore_M3_Concept_extends"));
+    }
+
+    @Test
+    public void reserializeLibrary() {
+        InputStream inputStream = this.getClass().getResourceAsStream("/serialization/library-metamodel.json");
+        JsonElement jsonElement = JsonParser.parseReader(new InputStreamReader(inputStream));
+        LowLevelJsonSerialization jsonSerialization = new LowLevelJsonSerialization();
+        SerializationBlock serializationBlock = jsonSerialization.readSerializationBlock(jsonElement);
+        JsonElement reserialized = jsonSerialization.serializeToJson(serializationBlock);
+        assertEquivalentLionWebJson(jsonElement.getAsJsonObject(), reserialized.getAsJsonObject());
+    }
+
+}

--- a/core/src/test/java/org/lionweb/lioncore/java/serialization/LowLevelJsonSerializationTest.java
+++ b/core/src/test/java/org/lionweb/lioncore/java/serialization/LowLevelJsonSerializationTest.java
@@ -4,7 +4,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import org.junit.Test;
 import org.lionweb.lioncore.java.serialization.data.MetaPointer;
-import org.lionweb.lioncore.java.serialization.data.SerializationBlock;
+import org.lionweb.lioncore.java.serialization.data.SerializedChunk;
 import org.lionweb.lioncore.java.serialization.data.SerializedNode;
 import org.lionweb.lioncore.java.serialization.data.SerializedReferenceValue;
 
@@ -24,8 +24,8 @@ public class LowLevelJsonSerializationTest {
         InputStream inputStream = this.getClass().getResourceAsStream("/serialization/lioncore.json");
         JsonElement jsonElement = JsonParser.parseReader(new InputStreamReader(inputStream));
         LowLevelJsonSerialization jsonSerialization = new LowLevelJsonSerialization();
-        SerializationBlock serializationBlock = jsonSerialization.unserializeSerializationBlock(jsonElement);
-        List<SerializedNode> unserializedSerializedNodeData = serializationBlock.getNodes();
+        SerializedChunk serializedChunk = jsonSerialization.unserializeSerializationBlock(jsonElement);
+        List<SerializedNode> unserializedSerializedNodeData = serializedChunk.getNodes();
 
         SerializedNode lioncore = unserializedSerializedNodeData.get(0);
         assertEquals(new MetaPointer("LIonCore_M3", "1", "LIonCore_M3_Metamodel"), lioncore.getConcept());
@@ -54,11 +54,11 @@ public class LowLevelJsonSerializationTest {
         InputStream inputStream = this.getClass().getResourceAsStream("/serialization/library-metamodel.json");
         JsonElement jsonElement = JsonParser.parseReader(new InputStreamReader(inputStream));
         LowLevelJsonSerialization jsonSerialization = new LowLevelJsonSerialization();
-        SerializationBlock serializationBlock = jsonSerialization.unserializeSerializationBlock(jsonElement);
-        SerializedNode book = serializationBlock.getNodeByID("library-Book");
+        SerializedChunk serializedChunk = jsonSerialization.unserializeSerializationBlock(jsonElement);
+        SerializedNode book = serializedChunk.getNodeByID("library-Book");
         assertEquals("Book", book.getPropertyValue("LIonCore_M3_NamespacedEntity_simpleName"));
 
-        SerializedNode guidedBookWriter = serializationBlock.getNodeByID("library-GuideBookWriter");
+        SerializedNode guidedBookWriter = serializedChunk.getNodeByID("library-GuideBookWriter");
         assertEquals("GuideBookWriter", guidedBookWriter.getPropertyValue("LIonCore_M3_NamespacedEntity_simpleName"));
         assertEquals(Arrays.asList(new SerializedReferenceValue.Entry("library-Writer", "Writer")), guidedBookWriter.getReferenceValues("LIonCore_M3_Concept_extends"));
     }
@@ -68,8 +68,8 @@ public class LowLevelJsonSerializationTest {
         InputStream inputStream = this.getClass().getResourceAsStream("/serialization/library-metamodel.json");
         JsonElement jsonElement = JsonParser.parseReader(new InputStreamReader(inputStream));
         LowLevelJsonSerialization jsonSerialization = new LowLevelJsonSerialization();
-        SerializationBlock serializationBlock = jsonSerialization.unserializeSerializationBlock(jsonElement);
-        JsonElement reserialized = jsonSerialization.serializeToJson(serializationBlock);
+        SerializedChunk serializedChunk = jsonSerialization.unserializeSerializationBlock(jsonElement);
+        JsonElement reserialized = jsonSerialization.serializeToJson(serializedChunk);
         assertEquivalentLionWebJson(jsonElement.getAsJsonObject(), reserialized.getAsJsonObject());
     }
 

--- a/core/src/test/java/org/lionweb/lioncore/java/serialization/SerializedJsonComparisonUtils.java
+++ b/core/src/test/java/org/lionweb/lioncore/java/serialization/SerializedJsonComparisonUtils.java
@@ -19,7 +19,7 @@ class SerializedJsonComparisonUtils {
     }
 
     static void assertEquivalentLionWebJson(JsonObject expected, JsonObject actual) {
-        Set<String> keys = new HashSet<>(Arrays.asList("serializationFormatVersion", "nodes"));
+        Set<String> keys = new HashSet<>(Arrays.asList("serializationFormatVersion", "nodes", "metamodels"));
         if (!expected.keySet().equals(keys)) {
             throw new RuntimeException("The expected object has irregular keys: " + expected.keySet());
         }
@@ -85,14 +85,23 @@ class SerializedJsonComparisonUtils {
             } else if (key.equals("id")) {
                 assertEquals("(" + context + ") different id", expected.get("id"), actual.get("id"));
             } else if (key.equals("references")) {
-                assertEquivalentObjects(expected.getAsJsonObject("references"), actual.getAsJsonObject("references"), "References of " + context);
+                assertEquivalentArrays(expected.getAsJsonArray("references"), actual.getAsJsonArray("references"), "References of " + context);
             } else if (key.equals("children")) {
-                assertEquivalentObjects(expected.getAsJsonObject("children"), actual.getAsJsonObject("children"), "Children of " + context);
+                assertEquivalentArrays(expected.getAsJsonArray("children"), actual.getAsJsonArray("children"), "Children of " + context);
             } else if (key.equals("properties")) {
-                assertEquivalentObjects(expected.getAsJsonObject("properties"), actual.getAsJsonObject("properties"), "Properties of " + context);
+                assertEquivalentArrays(expected.getAsJsonArray("properties"), actual.getAsJsonArray("properties"), "Properties of " + context);
             } else {
                 throw new AssertionError("(" + context + ") unexpected top-level key found: " + key);
             }
+        }
+    }
+
+    private static void assertEquivalentArrays(JsonArray expected, JsonArray actual, String context) {
+        if (expected.size() != actual.size()) {
+            throw new AssertionError("(" + context + ") Arrays with different sizes: expected=" + expected.size()+ " and actual=" + actual.size());
+        }
+        for (int i=0;i<expected.size();i++) {
+            assertEquivalentObjects(expected.get(i).getAsJsonObject(), actual.get(i).getAsJsonObject(), context + " element " + i);
         }
     }
 

--- a/core/src/test/resources/serialization/bobslibrary.json
+++ b/core/src/test/resources/serialization/bobslibrary.json
@@ -1,46 +1,110 @@
 {
   "serializationFormatVersion": "1",
+  "metamodels": [],
   "nodes": [
     {
-      "concept": "Pk1NRJfHMt4eSja2kpXia7x8vj6Vzc6WQCUzT3aVeYY",
       "id": "bl",
-      "properties": {
-        "LdgCnVXNgZD7CLbBhBin2Rcdumx4qZUYz_jh2QnP5z8": "Bob's Library"
+      "concept": {
+        "metamodel": "library",
+        "version": "1",
+        "key": "library-Library"
       },
-      "children": {
-        "TFS1ME6sEyRbkRchsr8zaZCcj_uF1LM0LXK24gbnxZM": [
-          "eb"
-        ]
-      },
-      "references": {}
+      "properties": [
+        {
+          "property": {
+            "metamodel": "library",
+            "version": "1",
+            "key": "library-Library-name"
+          },
+          "value": "Bob\u0027s Library"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "library",
+            "version": "1",
+            "key": "library-Library-books"
+          },
+          "children": [
+            "eb"
+          ]
+        }
+      ],
+      "references": [],
+      "parent": null
     },
     {
-      "concept": "OcDK2GESljInG-ApIqtkXUoA2UeviB97u0UuiZzM0Hs",
-      "id": "eb",
-      "properties": {
-        "Ei9m_HbdmEYg_EwMLLVZ71ERRBZyXH8GHVyOVia8Sqg": "Explorer Book",
-        "OJhF8vB_qRMrA8A9a-H0LsByONdYtHGmQ-lk9rUHUc4": null
-      },
-      "children": {},
-      "references": {
-        "9ATCb8nXEuQAL3NOY-EUZwuThpIQnQ2C_2n97IRGA_g": [
-          {
-            "resolveInfo": "Jack London",
-            "reference": "jl"
-          }
-        ]
-      },
-      "parent": "bl"
-    },
-    {
-      "concept": "nNUEzZ7it7d2HoHPAtk5rGO4SsqVA3hAlBwkK1KP8QU",
       "id": "jl",
-      "properties": {
-        "PoZyl6WXh-Cz5h2RspK1NL6zX9DdLwGpUUC-ygQmHMA": "Alaska",
-        "onRRrZaasiOtDU2qFJgyW8OVz8p5-hqQu0Vlc_7Aq6s": "Jack London"
+      "concept": {
+        "metamodel": "library",
+        "version": "1",
+        "key": "library-GuideBookWriter"
       },
-      "children": {},
-      "references": {}
+      "properties": [
+        {
+          "property": {
+            "metamodel": "library",
+            "version": "1",
+            "key": "library-GuideBookWriter-countries"
+          },
+          "value": "Alaska"
+        },
+        {
+          "property": {
+            "metamodel": "library",
+            "version": "1",
+            "key": "library-Writer-name"
+          },
+          "value": "Jack London"
+        }
+      ],
+      "children": [],
+      "references": [],
+      "parent": null
+    },
+    {
+      "id": "eb",
+      "concept": {
+        "metamodel": "library",
+        "version": "1",
+        "key": "library-Book"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "library",
+            "version": "1",
+            "key": "library-Book-title"
+          },
+          "value": "Explorer Book"
+        },
+        {
+          "property": {
+            "metamodel": "library",
+            "version": "1",
+            "key": "library-Book-pages"
+          },
+          "value": null
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "library",
+            "version": "1",
+            "key": "library-Book-author"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Jack London",
+              "reference": "jl"
+            }
+          ]
+        }
+      ],
+      "parent": "bl"
     }
   ]
 }

--- a/core/src/test/resources/serialization/foo-library.json
+++ b/core/src/test/resources/serialization/foo-library.json
@@ -1,22 +1,23 @@
 {
   "serializationFormatVersion": "1",
+  "metamodels": [],
   "nodes": [
     {
-      "concept": "OcDK2GESljInG-ApIqtkXUoA2UeviB97u0UuiZzM0Hs",
+      "concept": {"metamodel":"library","version":"1","key":"library-Book"},
       "id": "foo123",
-      "properties": {
-        "Ei9m_HbdmEYg_EwMLLVZ71ERRBZyXH8GHVyOVia8Sqg": null,
-        "OJhF8vB_qRMrA8A9a-H0LsByONdYtHGmQ-lk9rUHUc4": null
-      },
-      "children": {},
-      "references": {
-        "9ATCb8nXEuQAL3NOY-EUZwuThpIQnQ2C_2n97IRGA_g": [
+      "properties": [
+        {"property": {"metamodel":"library","version":"1","key":"library-Book-title"}, "value": null},
+        {"property": {"metamodel":"library","version":"1","key":"library-Book-pages"}, "value": null}
+      ],
+      "children": [],
+      "references": [
+        {"reference": {"metamodel":"library","version":"1","key":"library-Book-author"}, "targets": [
           {
             "reference": "_Arthur_Foozillus_id_",
             "resolveInfo": null
           }
         ]
-      }
+      }]
     }
   ]
 }

--- a/core/src/test/resources/serialization/langeng-library.json
+++ b/core/src/test/resources/serialization/langeng-library.json
@@ -1,55 +1,127 @@
 {
   "serializationFormatVersion": "1",
+  "metamodels": [],
   "nodes": [
     {
-      "concept": "Pk1NRJfHMt4eSja2kpXia7x8vj6Vzc6WQCUzT3aVeYY",
       "id": "lib-1",
-      "properties": {
-        "LdgCnVXNgZD7CLbBhBin2Rcdumx4qZUYz_jh2QnP5z8": "Language Engineering Library"
+      "concept": {
+        "metamodel": "library",
+        "version": "1",
+        "key": "library-Library"
       },
-      "children": {
-        "TFS1ME6sEyRbkRchsr8zaZCcj_uF1LM0LXK24gbnxZM": [
-          "de",
-          "bfd"
-        ]
-      },
-      "references": {}
+      "properties": [
+        {
+          "property": {
+            "metamodel": "library",
+            "version": "1",
+            "key": "library-Library-name"
+          },
+          "value": "Language Engineering Library"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "library",
+            "version": "1",
+            "key": "library-Library-books"
+          },
+          "children": [
+            "de",
+            "bfd"
+          ]
+        }
+      ],
+      "references": [],
+      "parent": null
     },
     {
-      "concept": "OcDK2GESljInG-ApIqtkXUoA2UeviB97u0UuiZzM0Hs",
       "id": "de",
-      "properties": {
-        "Ei9m_HbdmEYg_EwMLLVZ71ERRBZyXH8GHVyOVia8Sqg": "DSL Engineering",
-        "OJhF8vB_qRMrA8A9a-H0LsByONdYtHGmQ-lk9rUHUc4": "558"
+      "concept": {
+        "metamodel": "library",
+        "version": "1",
+        "key": "library-Book"
       },
-      "children": {},
-      "references": {
-        "9ATCb8nXEuQAL3NOY-EUZwuThpIQnQ2C_2n97IRGA_g": [
-          {
-            "resolveInfo": "Markus Völter",
-            "reference": "mv"
-          }
-        ]
-      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "library",
+            "version": "1",
+            "key": "library-Book-title"
+          },
+          "value": "DSL Engineering"
+        },
+        {
+          "property": {
+            "metamodel": "library",
+            "version": "1",
+            "key": "library-Book-pages"
+          },
+          "value": "558"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "library",
+            "version": "1",
+            "key": "library-Book-author"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Markus Völter",
+              "reference": "mv"
+            }
+          ]
+        }
+      ],
       "parent": "lib-1"
     },
     {
-      "concept": "OcDK2GESljInG-ApIqtkXUoA2UeviB97u0UuiZzM0Hs",
       "id": "bfd",
-      "properties": {
-        "Ei9m_HbdmEYg_EwMLLVZ71ERRBZyXH8GHVyOVia8Sqg": "Business-Friendly DSLs",
-        "OJhF8vB_qRMrA8A9a-H0LsByONdYtHGmQ-lk9rUHUc4": "517"
+      "concept": {
+        "metamodel": "library",
+        "version": "1",
+        "key": "library-Book"
       },
-      "children": {},
-      "references": {
-        "9ATCb8nXEuQAL3NOY-EUZwuThpIQnQ2C_2n97IRGA_g": [
-          {
-            "resolveInfo": "Meinte Boersma",
-            "reference": "mb"
-          }
-        ]
-      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "library",
+            "version": "1",
+            "key": "library-Book-title"
+          },
+          "value": "Business-Friendly DSLs"
+        },
+        {
+          "property": {
+            "metamodel": "library",
+            "version": "1",
+            "key": "library-Book-pages"
+          },
+          "value": "517"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "library",
+            "version": "1",
+            "key": "library-Book-author"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Meinte Boersma",
+              "reference": "mb"
+            }
+          ]
+        }
+      ],
       "parent": "lib-1"
     }
   ]
 }
+
+

--- a/core/src/test/resources/serialization/library-metamodel.json
+++ b/core/src/test/resources/serialization/library-metamodel.json
@@ -1,327 +1,997 @@
 {
   "serializationFormatVersion": "1",
+  "metamodels": [],
   "nodes": [
     {
-      "concept": "LIonCore_M3_Metamodel",
-      "id": "txjxNU9yRzEuyghtmgJK_l-nF93qWt7d1vErz5RbLow",
-      "properties": {
-        "LIonCore_M3_Metamodel_name": "library"
+      "id": "library",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Metamodel"
       },
-      "children": {
-        "LIonCore_M3_Metamodel_elements": [
-          "INhBvWyXvxwNsePuX0rdNGB_J9hi85cTb1Q0APXCyJ0",
-          "uHmTCy63BV23cvXwFSumVwK1DOh4IZvIyAnRJjW9eQI",
-          "gVp8_QSmXE2k4pd-sQZgjYMoW95SLLaVIH4yMYqqbt4",
-          "OcDK2GESljInG-ApIqtkXUoA2UeviB97u0UuiZzM0Hs",
-          "Pk1NRJfHMt4eSja2kpXia7x8vj6Vzc6WQCUzT3aVeYY",
-          "DuBg-a_slgc_VOG0huySkSWi3rZQX1Q20EEd2f7lvLE",
-          "nNUEzZ7it7d2HoHPAtk5rGO4SsqVA3hAlBwkK1KP8QU",
-          "RDa_L8gbU8XgW9z46oMysBi1Hb7vjcS8O8LUgXlFpeU"
-        ]
-      },
-      "references": {
-      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Metamodel_name"
+          },
+          "value": "library"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Metamodel_version"
+          },
+          "value": "1"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "library"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Metamodel_elements"
+          },
+          "children": [
+            "library-Book",
+            "library-Library",
+            "library-Writer",
+            "library-GuideBookWriter",
+            "library-SpecialistBookWriter"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Metamodel_dependsOn"
+          },
+          "targets": []
+        }
+      ],
       "parent": null
     },
     {
-      "concept": "LIonCore_M3_PrimitiveType",
-      "id": "INhBvWyXvxwNsePuX0rdNGB_J9hi85cTb1Q0APXCyJ0",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "String"
+      "id": "library-Book",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Concept"
       },
-      "children": {
-      },
-      "references": {
-      },
-      "parent": "txjxNU9yRzEuyghtmgJK_l-nF93qWt7d1vErz5RbLow"
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "Book"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "library.Book"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "library-Book"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_FeaturesContainer_features"
+          },
+          "children": [
+            "library-Book-title",
+            "library-Book-pages",
+            "library-Book-author"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_extends"
+          },
+          "targets": []
+        },
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_implements"
+          },
+          "targets": []
+        }
+      ],
+      "parent": "library"
     },
     {
-      "concept": "LIonCore_M3_PrimitiveType",
-      "id": "uHmTCy63BV23cvXwFSumVwK1DOh4IZvIyAnRJjW9eQI",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "boolean"
+      "id": "library-Book-title",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Property"
       },
-      "references": {
-      },
-      "children": {
-      },
-      "parent": "txjxNU9yRzEuyghtmgJK_l-nF93qWt7d1vErz5RbLow"
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "title"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "library.Book.title"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "library-Book-title"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Property_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LIonCore_M3_String"
+            }
+          ]
+        }
+      ],
+      "parent": "library-Book"
     },
     {
-      "concept": "LIonCore_M3_PrimitiveType",
-      "id": "gVp8_QSmXE2k4pd-sQZgjYMoW95SLLaVIH4yMYqqbt4",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "int"
+      "id": "library-Book-pages",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Property"
       },
-      "children": {
-      },
-      "references": {
-      },
-      "parent": "txjxNU9yRzEuyghtmgJK_l-nF93qWt7d1vErz5RbLow"
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "pages"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "library.Book.pages"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "library-Book-pages"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Property_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Integer",
+              "reference": "LIonCore_M3_Integer"
+            }
+          ]
+        }
+      ],
+      "parent": "library-Book"
     },
     {
-      "concept": "LIonCore_M3_Concept",
-      "id": "OcDK2GESljInG-ApIqtkXUoA2UeviB97u0UuiZzM0Hs",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "Book",
-        "LIonCore_M3_Concept_abstract": "false"
+      "id": "library-Book-author",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Reference"
       },
-      "children": {
-        "LIonCore_M3_FeaturesContainer_features": [
-          "Ei9m_HbdmEYg_EwMLLVZ71ERRBZyXH8GHVyOVia8Sqg",
-          "OJhF8vB_qRMrA8A9a-H0LsByONdYtHGmQ-lk9rUHUc4",
-          "9ATCb8nXEuQAL3NOY-EUZwuThpIQnQ2C_2n97IRGA_g"
-        ]
-      },
-      "references": {
-        "LIonCore_M3_Concept_extends": [],
-        "LIonCore_M3_Concept_implements": []
-      },
-      "parent": "txjxNU9yRzEuyghtmgJK_l-nF93qWt7d1vErz5RbLow"
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Link_multiple"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "author"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "library.Book.author"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "library-Book-author"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Link_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Writer",
+              "reference": "library-Writer"
+            }
+          ]
+        }
+      ],
+      "parent": "library-Book"
     },
     {
-      "concept": "LIonCore_M3_Property",
-      "id": "Ei9m_HbdmEYg_EwMLLVZ71ERRBZyXH8GHVyOVia8Sqg",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "title",
-        "LIonCore_M3_Feature_optional": "false",
-        "LIonCore_M3_Feature_derived": "false"
+      "id": "library-Library",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Concept"
       },
-      "children": {
-      },
-      "references": {
-        "LIonCore_M3_Property_type": [
-          {
-            "resolveInfo": null,
-            "reference": "INhBvWyXvxwNsePuX0rdNGB_J9hi85cTb1Q0APXCyJ0"
-          }
-        ]
-      },
-      "parent": "OcDK2GESljInG-ApIqtkXUoA2UeviB97u0UuiZzM0Hs"
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "Library"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "library.Library"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "library-Library"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_FeaturesContainer_features"
+          },
+          "children": [
+            "library-Library-name",
+            "library-Library-books"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_extends"
+          },
+          "targets": []
+        },
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_implements"
+          },
+          "targets": []
+        }
+      ],
+      "parent": "library"
     },
     {
-      "concept": "LIonCore_M3_Property",
-      "id": "OJhF8vB_qRMrA8A9a-H0LsByONdYtHGmQ-lk9rUHUc4",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "pages",
-        "LIonCore_M3_Feature_optional": "false",
-        "LIonCore_M3_Feature_derived": "false"
+      "id": "library-Library-name",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Property"
       },
-      "children": {
-      },
-      "references": {
-        "LIonCore_M3_Property_type": [
-          {
-            "resolveInfo": null,
-            "reference": "gVp8_QSmXE2k4pd-sQZgjYMoW95SLLaVIH4yMYqqbt4"
-          }
-        ]
-      },
-      "parent": "OcDK2GESljInG-ApIqtkXUoA2UeviB97u0UuiZzM0Hs"
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "name"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "library.Library.name"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "library-Library-name"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Property_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LIonCore_M3_String"
+            }
+          ]
+        }
+      ],
+      "parent": "library-Library"
     },
     {
-      "concept": "LIonCore_M3_Reference",
-      "id": "9ATCb8nXEuQAL3NOY-EUZwuThpIQnQ2C_2n97IRGA_g",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "author",
-        "LIonCore_M3_Feature_optional": "false",
-        "LIonCore_M3_Feature_derived": "false",
-        "LIonCore_M3_Link_multiple": "true"
+      "id": "library-Library-books",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Containment"
       },
-      "references": {
-        "LIonCore_M3_Link_type": [
-          {
-            "resolveInfo": null,
-            "reference": "DuBg-a_slgc_VOG0huySkSWi3rZQX1Q20EEd2f7lvLE"
-          }
-        ]
-      },
-      "children": {},
-      "parent": "OcDK2GESljInG-ApIqtkXUoA2UeviB97u0UuiZzM0Hs"
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Link_multiple"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "books"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "library.Library.books"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "library-Library-books"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Link_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Book",
+              "reference": "library-Book"
+            }
+          ]
+        }
+      ],
+      "parent": "library-Library"
     },
     {
-      "concept": "LIonCore_M3_Concept",
-      "id": "Pk1NRJfHMt4eSja2kpXia7x8vj6Vzc6WQCUzT3aVeYY",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "Library",
-        "LIonCore_M3_Concept_abstract": "false"
+      "id": "library-Writer",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Concept"
       },
-      "children": {
-        "LIonCore_M3_FeaturesContainer_features": [
-          "LdgCnVXNgZD7CLbBhBin2Rcdumx4qZUYz_jh2QnP5z8",
-          "TFS1ME6sEyRbkRchsr8zaZCcj_uF1LM0LXK24gbnxZM"
-        ]
-      },
-      "references": {
-        "LIonCore_M3_Concept_extends": [],
-        "LIonCore_M3_Concept_implements": []
-      },
-      "parent": "txjxNU9yRzEuyghtmgJK_l-nF93qWt7d1vErz5RbLow"
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "Writer"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "library.Writer"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "library-Writer"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_FeaturesContainer_features"
+          },
+          "children": [
+            "library-Writer-name"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_extends"
+          },
+          "targets": []
+        },
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_implements"
+          },
+          "targets": []
+        }
+      ],
+      "parent": "library"
     },
     {
-      "concept": "LIonCore_M3_Property",
-      "id": "LdgCnVXNgZD7CLbBhBin2Rcdumx4qZUYz_jh2QnP5z8",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "name",
-        "LIonCore_M3_Feature_optional": "false",
-        "LIonCore_M3_Feature_derived": "false"
+      "id": "library-Writer-name",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Property"
       },
-      "children": {
-      },
-      "references": {
-        "LIonCore_M3_Property_type": [
-          {
-            "reference": "INhBvWyXvxwNsePuX0rdNGB_J9hi85cTb1Q0APXCyJ0",
-            "resolveInfo": null
-          }
-        ]
-      },
-      "parent": "Pk1NRJfHMt4eSja2kpXia7x8vj6Vzc6WQCUzT3aVeYY"
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "name"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "library.Writer.name"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "library-Writer-name"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Property_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LIonCore_M3_String"
+            }
+          ]
+        }
+      ],
+      "parent": "library-Writer"
     },
     {
-      "concept": "LIonCore_M3_Containment",
-      "id": "TFS1ME6sEyRbkRchsr8zaZCcj_uF1LM0LXK24gbnxZM",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "books",
-        "LIonCore_M3_Feature_optional": "false",
-        "LIonCore_M3_Feature_derived": "false",
-        "LIonCore_M3_Link_multiple": "true"
+      "id": "library-GuideBookWriter",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Concept"
       },
-      "children": {
-      },
-      "references": {
-        "LIonCore_M3_Link_type": [
-          {
-            "reference": "OcDK2GESljInG-ApIqtkXUoA2UeviB97u0UuiZzM0Hs",
-            "resolveInfo": null
-          }
-        ]
-      },
-      "parent": "Pk1NRJfHMt4eSja2kpXia7x8vj6Vzc6WQCUzT3aVeYY"
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "GuideBookWriter"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "library.GuideBookWriter"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "library-GuideBookWriter"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_FeaturesContainer_features"
+          },
+          "children": [
+            "library-GuideBookWriter-countries"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Writer",
+              "reference": "library-Writer"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_implements"
+          },
+          "targets": []
+        }
+      ],
+      "parent": "library"
     },
     {
-      "concept": "LIonCore_M3_Concept",
-      "id": "DuBg-a_slgc_VOG0huySkSWi3rZQX1Q20EEd2f7lvLE",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "Writer",
-        "LIonCore_M3_Concept_abstract": "false"
+      "id": "library-GuideBookWriter-countries",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Property"
       },
-      "children": {
-        "LIonCore_M3_FeaturesContainer_features": [
-          "onRRrZaasiOtDU2qFJgyW8OVz8p5-hqQu0Vlc_7Aq6s"
-        ]
-      },
-      "references": {
-        "LIonCore_M3_Concept_extends": [],
-        "LIonCore_M3_Concept_implements": []
-      },
-      "parent": "txjxNU9yRzEuyghtmgJK_l-nF93qWt7d1vErz5RbLow"
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "countries"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "library.GuideBookWriter.countries"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "library-GuideBookWriter-countries"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Property_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LIonCore_M3_String"
+            }
+          ]
+        }
+      ],
+      "parent": "library-GuideBookWriter"
     },
     {
-      "concept": "LIonCore_M3_Property",
-      "id": "onRRrZaasiOtDU2qFJgyW8OVz8p5-hqQu0Vlc_7Aq6s",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "name",
-        "LIonCore_M3_Feature_optional": "false",
-        "LIonCore_M3_Feature_derived": "false"
+      "id": "library-SpecialistBookWriter",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Concept"
       },
-      "children": {
-      },
-      "references": {
-        "LIonCore_M3_Property_type": [
-          {
-            "reference": "INhBvWyXvxwNsePuX0rdNGB_J9hi85cTb1Q0APXCyJ0",
-            "resolveInfo": null
-          }
-        ]
-      },
-      "parent": "DuBg-a_slgc_VOG0huySkSWi3rZQX1Q20EEd2f7lvLE"
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "SpecialistBookWriter"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "library.SpecialistBookWriter"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "library-SpecialistBookWriter"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_FeaturesContainer_features"
+          },
+          "children": [
+            "library-SpecialistBookWriter-subject"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Writer",
+              "reference": "library-Writer"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_implements"
+          },
+          "targets": []
+        }
+      ],
+      "parent": "library"
     },
     {
-      "concept": "LIonCore_M3_Concept",
-      "id": "nNUEzZ7it7d2HoHPAtk5rGO4SsqVA3hAlBwkK1KP8QU",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "GuideBookWriter",
-        "LIonCore_M3_Concept_abstract": "false"
+      "id": "library-SpecialistBookWriter-subject",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Property"
       },
-      "children": {
-        "LIonCore_M3_FeaturesContainer_features": [
-          "PoZyl6WXh-Cz5h2RspK1NL6zX9DdLwGpUUC-ygQmHMA"
-        ]
-      },
-      "references": {
-        "LIonCore_M3_Concept_extends": [
-          {
-            "reference": "DuBg-a_slgc_VOG0huySkSWi3rZQX1Q20EEd2f7lvLE",
-            "resolveInfo": null
-          }
-        ],
-        "LIonCore_M3_Concept_implements": []
-      },
-      "parent": "txjxNU9yRzEuyghtmgJK_l-nF93qWt7d1vErz5RbLow"
-    },
-    {
-      "concept": "LIonCore_M3_Property",
-      "id": "PoZyl6WXh-Cz5h2RspK1NL6zX9DdLwGpUUC-ygQmHMA",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "countries",
-        "LIonCore_M3_Feature_optional": "false",
-        "LIonCore_M3_Feature_derived": "false"
-      },
-      "children": {
-      },
-      "references": {
-        "LIonCore_M3_Property_type": [
-          {
-            "reference": "INhBvWyXvxwNsePuX0rdNGB_J9hi85cTb1Q0APXCyJ0",
-            "resolveInfo": null
-          }
-        ]
-      },
-      "parent": "nNUEzZ7it7d2HoHPAtk5rGO4SsqVA3hAlBwkK1KP8QU"
-    },
-    {
-      "concept": "LIonCore_M3_Concept",
-      "id": "RDa_L8gbU8XgW9z46oMysBi1Hb7vjcS8O8LUgXlFpeU",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "SpecialistBookWriter",
-        "LIonCore_M3_Concept_abstract": "false"
-      },
-      "children": {
-        "LIonCore_M3_FeaturesContainer_features": [
-          "DbVixG73dI8xIF9TAoq2GOZru4CRQfRD8gG7TkFCZuU"
-        ]
-      },
-      "references": {
-        "LIonCore_M3_Concept_extends": [
-          {
-            "reference": "DuBg-a_slgc_VOG0huySkSWi3rZQX1Q20EEd2f7lvLE",
-            "resolveInfo": null
-          }
-        ],
-        "LIonCore_M3_Concept_implements": []
-      },
-      "parent": "txjxNU9yRzEuyghtmgJK_l-nF93qWt7d1vErz5RbLow"
-    },
-    {
-      "concept": "LIonCore_M3_Property",
-      "id": "DbVixG73dI8xIF9TAoq2GOZru4CRQfRD8gG7TkFCZuU",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "subject",
-        "LIonCore_M3_Feature_optional": "false",
-        "LIonCore_M3_Feature_derived": "false"
-      },
-      "children": {
-      },
-      "references": {
-        "LIonCore_M3_Property_type": [
-          {
-            "reference": "INhBvWyXvxwNsePuX0rdNGB_J9hi85cTb1Q0APXCyJ0",
-            "resolveInfo": null
-          }
-        ]
-      },
-      "parent": "RDa_L8gbU8XgW9z46oMysBi1Hb7vjcS8O8LUgXlFpeU"
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "subject"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "library.SpecialistBookWriter.subject"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "library-SpecialistBookWriter-subject"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Property_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LIonCore_M3_String"
+            }
+          ]
+        }
+      ],
+      "parent": "library-SpecialistBookWriter"
     }
   ]
 }

--- a/core/src/test/resources/serialization/lioncore.json
+++ b/core/src/test/resources/serialization/lioncore.json
@@ -1,760 +1,2653 @@
 {
   "serializationFormatVersion": "1",
+  "metamodels": [],
   "nodes": [
     {
-      "concept": "LIonCore_M3_Metamodel",
       "id": "LIonCore_M3",
-      "properties": {
-        "LIonCore_M3_Metamodel_name": "LIonCore.M3"
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Metamodel"
       },
-      "children": {
-        "LIonCore_M3_Metamodel_elements": [
-          "LIonCore_M3_NamespacedEntity",
-          "LIonCore_M3_NamespaceProvider",
-          "LIonCore_M3_Metamodel",
-          "LIonCore_M3_MetamodelElement",
-          "LIonCore_M3_FeaturesContainer",
-          "LIonCore_M3_Concept",
-          "LIonCore_M3_ConceptInterface",
-          "LIonCore_M3_Feature",
-          "LIonCore_M3_Link",
-          "LIonCore_M3_Reference",
-          "LIonCore_M3_Property",
-          "LIonCore_M3_DataType",
-          "LIonCore_M3_PrimitiveType",
-          "LIonCore_M3_Containment",
-          "LIonCore_M3_Enumeration",
-          "LIonCore_M3_EnumerationLiteral"
-        ]
-      },
-      "references": {}
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Metamodel_name"
+          },
+          "value": "LIonCore.M3"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Metamodel_version"
+          },
+          "value": "1"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "LIonCore_M3"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Metamodel_elements"
+          },
+          "children": [
+            "LIonCore_M3_Concept",
+            "LIonCore_M3_ConceptInterface",
+            "LIonCore_M3_Containment",
+            "LIonCore_M3_DataType",
+            "LIonCore_M3_Enumeration",
+            "LIonCore_M3_EnumerationLiteral",
+            "LIonCore_M3_Feature",
+            "LIonCore_M3_FeaturesContainer",
+            "LIonCore_M3_HasKey",
+            "LIonCore_M3_Link",
+            "LIonCore_M3_Metamodel",
+            "LIonCore_M3_MetamodelElement",
+            "LIonCore_M3_NamespacedEntity",
+            "LIonCore_M3_NamespaceProvider",
+            "LIonCore_M3_PrimitiveType",
+            "LIonCore_M3_Property",
+            "LIonCore_M3_Reference"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Metamodel_dependsOn"
+          },
+          "targets": []
+        }
+      ],
+      "parent": null
     },
     {
-      "concept": "LIonCore_M3_Concept",
-      "id": "LIonCore_M3_NamespacedEntity",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "NamespacedEntity",
-        "LIonCore_M3_Concept_abstract": true
-      },
-      "children": {
-        "LIonCore_M3_FeaturesContainer_features": [
-          "LIonCore_M3_NamespacedEntity_simpleName",
-          "LIonCore_M3_NamespacedEntity_qualifiedName"
-        ]
-      },
-      "references": {
-        "LIonCore_M3_Concept_extends": [],
-        "LIonCore_M3_Concept_implements": []
-      },
-      "parent": "LIonCore_M3"
-    },
-    {
-      "concept": "LIonCore_M3_Property",
-      "id": "LIonCore_M3_NamespacedEntity_simpleName",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "simpleName",
-        "LIonCore_M3_Feature_optional": false,
-        "LIonCore_M3_Feature_derived": false
-      },
-      "references": {
-        "LIonCore_M3_Property_type": [
-          {
-            "resolveInfo": null,
-            "reference": "LIonCore_M3_String"
-          }
-        ]
-      },
-      "parent": "LIonCore_M3_NamespacedEntity"
-    },
-    {
-      "concept": "LIonCore_M3_Property",
-      "id": "LIonCore_M3_NamespacedEntity_qualifiedName",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "qualifiedName",
-        "LIonCore_M3_Feature_optional": false,
-        "LIonCore_M3_Feature_derived": true
-      },
-      "references": {
-        "LIonCore_M3_Property_type": [
-          {
-            "resolveInfo": null,
-            "reference": "LIonCore_M3_String"
-          }
-        ]
-      },
-      "parent": "LIonCore_M3_NamespacedEntity"
-    },
-    {
-      "concept": "LIonCore_M3_ConceptInterface",
-      "id": "LIonCore_M3_NamespaceProvider",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "NamespaceProvider"
-      },
-      "children": {
-        "LIonCore_M3_FeaturesContainer_features": [
-          "LIonCore_M3_NamespaceProvider_namespaceQualifier"
-        ]
-      },
-      "references": {
-        "LIonCore_M3_ConceptInterface_extends": []
-      },
-      "parent": "LIonCore_M3"
-    },
-    {
-      "concept": "LIonCore_M3_Property",
-      "id": "LIonCore_M3_NamespaceProvider_namespaceQualifier",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "namespaceQualifier",
-        "LIonCore_M3_Feature_optional": false,
-        "LIonCore_M3_Feature_derived": true
-      },
-      "references": {
-        "LIonCore_M3_Property_type": [
-          {
-            "resolveInfo": null,
-            "reference": "LIonCore_M3_String"
-          }
-        ]
-      },
-      "parent": "LIonCore_M3_NamespaceProvider"
-    },
-    {
-      "concept": "LIonCore_M3_Concept",
-      "id": "LIonCore_M3_Metamodel",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "Metamodel",
-        "LIonCore_M3_Concept_abstract": false
-      },
-      "children": {
-        "LIonCore_M3_FeaturesContainer_features": [
-          "LIonCore_M3_Metamodel_name",
-          "LIonCore_M3_Metamodel_elements",
-          "LIonCore_M3_Metamodel_dependsOn"
-        ]
-      },
-      "references": {
-        "LIonCore_M3_Concept_extends": [],
-        "LIonCore_M3_Concept_implements": [
-          {
-            "resolveInfo": null,
-            "reference": "LIonCore_M3_NamespaceProvider"
-          }
-        ]
-      },
-      "parent": "LIonCore_M3"
-    },
-    {
-      "concept": "LIonCore_M3_Property",
-      "id": "LIonCore_M3_Metamodel_name",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "qualifiedName",
-        "LIonCore_M3_Feature_optional": false,
-        "LIonCore_M3_Feature_derived": false
-      },
-      "references": {
-        "LIonCore_M3_Property_type": [
-          {
-            "resolveInfo": null,
-            "reference": "LIonCore_M3_String"
-          }
-        ]
-      },
-      "parent": "LIonCore_M3_Metamodel"
-    },
-    {
-      "concept": "LIonCore_M3_Containment",
-      "id": "LIonCore_M3_Metamodel_elements",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "elements",
-        "LIonCore_M3_Feature_optional": true,
-        "LIonCore_M3_Feature_derived": false,
-        "LIonCore_M3_Link_multiple": true
-      },
-      "references": {
-        "LIonCore_M3_Link_type": [
-          {
-            "resolveInfo": null,
-            "reference": "LIonCore_M3_MetamodelElement"
-          }
-        ]
-      },
-      "parent": "LIonCore_M3_Metamodel"
-    },
-    {
-      "concept": "LIonCore_M3_Reference",
-      "id": "LIonCore_M3_Metamodel_dependsOn",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "dependsOn",
-        "LIonCore_M3_Feature_optional": true,
-        "LIonCore_M3_Feature_derived": false,
-        "LIonCore_M3_Link_multiple": true
-      },
-      "references": {
-        "LIonCore_M3_Link_type": [
-          {
-            "resolveInfo": null,
-            "reference": "LIonCore_M3_Metamodel"
-          }
-        ]
-      },
-      "parent": "LIonCore_M3_Metamodel"
-    },
-    {
-      "concept": "LIonCore_M3_Concept",
-      "id": "LIonCore_M3_MetamodelElement",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "MetamodelElement",
-        "LIonCore_M3_Concept_abstract": true
-      },
-      "children": {
-        "LIonCore_M3_FeaturesContainer_features": []
-      },
-      "references": {
-        "LIonCore_M3_Concept_extends": [
-          {
-            "resolveInfo": null,
-            "reference": "LIonCore_M3_NamespacedEntity"
-          }
-        ],
-        "LIonCore_M3_Concept_implements": []
-      },
-      "parent": "LIonCore_M3"
-    },
-    {
-      "concept": "LIonCore_M3_Concept",
-      "id": "LIonCore_M3_FeaturesContainer",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "FeaturesContainer",
-        "LIonCore_M3_Concept_abstract": true
-      },
-      "children": {
-        "LIonCore_M3_FeaturesContainer_features": [
-          "LIonCore_M3_FeaturesContainer_features",
-          "LIonCore_M3_FeaturesContainer_allFeatures"
-        ]
-      },
-      "references": {
-        "LIonCore_M3_Concept_extends": [
-          {
-            "resolveInfo": null,
-            "reference": "LIonCore_M3_MetamodelElement"
-          }
-        ],
-        "LIonCore_M3_Concept_implements": [
-          {
-            "resolveInfo": null,
-            "reference": "LIonCore_M3_NamespaceProvider"
-          }
-        ]
-      },
-      "parent": "LIonCore_M3"
-    },
-    {
-      "concept": "LIonCore_M3_Containment",
-      "id": "LIonCore_M3_FeaturesContainer_features",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "features",
-        "LIonCore_M3_Feature_optional": true,
-        "LIonCore_M3_Feature_derived": false,
-        "LIonCore_M3_Link_multiple": true
-      },
-      "references": {
-        "LIonCore_M3_Link_type": [
-          {
-            "resolveInfo": null,
-            "reference": "LIonCore_M3_Feature"
-          }
-        ]
-      },
-      "parent": "LIonCore_M3_FeaturesContainer"
-    },
-    {
-      "concept": "LIonCore_M3_Reference",
-      "id": "LIonCore_M3_FeaturesContainer_allFeatures",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "allFeatures",
-        "LIonCore_M3_Feature_optional": true,
-        "LIonCore_M3_Feature_derived": true,
-        "LIonCore_M3_Link_multiple": true
-      },
-      "references": {
-        "LIonCore_M3_Link_type": [
-          {
-            "resolveInfo": null,
-            "reference": "LIonCore_M3_Feature"
-          }
-        ]
-      },
-      "parent": "LIonCore_M3_FeaturesContainer"
-    },
-    {
-      "concept": "LIonCore_M3_Concept",
       "id": "LIonCore_M3_Concept",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "Concept",
-        "LIonCore_M3_Concept_abstract": false
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Concept"
       },
-      "children": {
-        "LIonCore_M3_FeaturesContainer_features": [
-          "LIonCore_M3_Concept_abstract",
-          "LIonCore_M3_Concept_extends",
-          "LIonCore_M3_Concept_implements"
-        ]
-      },
-      "references": {
-        "LIonCore_M3_Concept_extends": [
-          {
-            "resolveInfo": null,
-            "reference": "LIonCore_M3_FeaturesContainer"
-          }
-        ],
-        "LIonCore_M3_Concept_implements": []
-      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_abstract"
+          },
+          "value": null
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "Concept"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "LIonCore.M3.Concept"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "LIonCore_M3_Concept"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_FeaturesContainer_features"
+          },
+          "children": [
+            "LIonCore_M3_Concept_abstract",
+            "LIonCore_M3_Concept_extends",
+            "LIonCore_M3_Concept_implements"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "FeaturesContainer",
+              "reference": "LIonCore_M3_FeaturesContainer"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_implements"
+          },
+          "targets": []
+        }
+      ],
       "parent": "LIonCore_M3"
     },
     {
-      "concept": "LIonCore_M3_Property",
       "id": "LIonCore_M3_Concept_abstract",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "abstract",
-        "LIonCore_M3_Feature_optional": false,
-        "LIonCore_M3_Feature_derived": false
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Property"
       },
-      "references": {
-        "LIonCore_M3_Property_type": [
-          {
-            "resolveInfo": null,
-            "reference": "LIonCore_M3_boolean"
-          }
-        ]
-      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "abstract"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "LIonCore.M3.Concept.abstract"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "LIonCore_M3_Concept_abstract"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Property_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Boolean",
+              "reference": "LIonCore_M3_Boolean"
+            }
+          ]
+        }
+      ],
       "parent": "LIonCore_M3_Concept"
     },
     {
-      "concept": "LIonCore_M3_Reference",
       "id": "LIonCore_M3_Concept_extends",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "extends",
-        "LIonCore_M3_Feature_optional": true,
-        "LIonCore_M3_Feature_derived": false,
-        "LIonCore_M3_Link_multiple": false
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Reference"
       },
-      "references": {
-        "LIonCore_M3_Link_type": [
-          {
-            "resolveInfo": null,
-            "reference": "LIonCore_M3_Concept"
-          }
-        ]
-      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Link_multiple"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "extends"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "LIonCore.M3.Concept.extends"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "LIonCore_M3_Concept_extends"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Link_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Concept",
+              "reference": "LIonCore_M3_Concept"
+            }
+          ]
+        }
+      ],
       "parent": "LIonCore_M3_Concept"
     },
     {
-      "concept": "LIonCore_M3_Reference",
       "id": "LIonCore_M3_Concept_implements",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "implements",
-        "LIonCore_M3_Feature_optional": true,
-        "LIonCore_M3_Feature_derived": false,
-        "LIonCore_M3_Link_multiple": true
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Reference"
       },
-      "references": {
-        "LIonCore_M3_Link_type": [
-          {
-            "resolveInfo": null,
-            "reference": "LIonCore_M3_ConceptInterface"
-          }
-        ]
-      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Link_multiple"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "implements"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "LIonCore.M3.Concept.implements"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "LIonCore_M3_Concept_implements"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Link_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "ConceptInterface",
+              "reference": "LIonCore_M3_ConceptInterface"
+            }
+          ]
+        }
+      ],
       "parent": "LIonCore_M3_Concept"
     },
     {
-      "concept": "LIonCore_M3_Concept",
       "id": "LIonCore_M3_ConceptInterface",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "ConceptInterface",
-        "LIonCore_M3_Concept_abstract": false
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Concept"
       },
-      "children": {
-        "LIonCore_M3_FeaturesContainer_features": [
-          "LIonCore_M3_ConceptInterface_extends"
-        ]
-      },
-      "references": {
-        "LIonCore_M3_Concept_extends": [
-          {
-            "resolveInfo": null,
-            "reference": "LIonCore_M3_FeaturesContainer"
-          }
-        ],
-        "LIonCore_M3_Concept_implements": []
-      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_abstract"
+          },
+          "value": null
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "ConceptInterface"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "LIonCore.M3.ConceptInterface"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "LIonCore_M3_ConceptInterface"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_FeaturesContainer_features"
+          },
+          "children": [
+            "LIonCore_M3_ConceptInterface_extends"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "FeaturesContainer",
+              "reference": "LIonCore_M3_FeaturesContainer"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_implements"
+          },
+          "targets": []
+        }
+      ],
       "parent": "LIonCore_M3"
     },
     {
-      "concept": "LIonCore_M3_Reference",
       "id": "LIonCore_M3_ConceptInterface_extends",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "extends",
-        "LIonCore_M3_Feature_optional": true,
-        "LIonCore_M3_Feature_derived": false,
-        "LIonCore_M3_Link_multiple": true
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Reference"
       },
-      "references": {
-        "LIonCore_M3_Link_type": [
-          {
-            "resolveInfo": null,
-            "reference": "LIonCore_M3_ConceptInterface"
-          }
-        ]
-      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Link_multiple"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "extends"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "LIonCore.M3.ConceptInterface.extends"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "LIonCore_M3_ConceptInterface_extends"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Link_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "ConceptInterface",
+              "reference": "LIonCore_M3_ConceptInterface"
+            }
+          ]
+        }
+      ],
       "parent": "LIonCore_M3_ConceptInterface"
     },
     {
-      "concept": "LIonCore_M3_Concept",
-      "id": "LIonCore_M3_Feature",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "Feature",
-        "LIonCore_M3_Concept_abstract": true
-      },
-      "children": {
-        "LIonCore_M3_FeaturesContainer_features": [
-          "LIonCore_M3_Feature_optional",
-          "LIonCore_M3_Feature_derived"
-        ]
-      },
-      "references": {
-        "LIonCore_M3_Concept_extends": [
-          {
-            "resolveInfo": null,
-            "reference": "LIonCore_M3_NamespacedEntity"
-          }
-        ],
-        "LIonCore_M3_Concept_implements": []
-      },
-      "parent": "LIonCore_M3"
-    },
-    {
-      "concept": "LIonCore_M3_Property",
-      "id": "LIonCore_M3_Feature_optional",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "optional",
-        "LIonCore_M3_Feature_optional": false,
-        "LIonCore_M3_Feature_derived": false
-      },
-      "references": {
-        "LIonCore_M3_Property_type": [
-          {
-            "resolveInfo": null,
-            "reference": "LIonCore_M3_boolean"
-          }
-        ]
-      },
-      "parent": "LIonCore_M3_Feature"
-    },
-    {
-      "concept": "LIonCore_M3_Property",
-      "id": "LIonCore_M3_Feature_derived",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "derived",
-        "LIonCore_M3_Feature_optional": false,
-        "LIonCore_M3_Feature_derived": false
-      },
-      "references": {
-        "LIonCore_M3_Property_type": [
-          {
-            "resolveInfo": null,
-            "reference": "LIonCore_M3_boolean"
-          }
-        ]
-      },
-      "parent": "LIonCore_M3_Feature"
-    },
-    {
-      "concept": "LIonCore_M3_Concept",
-      "id": "LIonCore_M3_Link",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "Link",
-        "LIonCore_M3_Concept_abstract": true
-      },
-      "children": {
-        "LIonCore_M3_FeaturesContainer_features": [
-          "LIonCore_M3_Link_multiple",
-          "LIonCore_M3_Link_type"
-        ]
-      },
-      "references": {
-        "LIonCore_M3_Concept_extends": [
-          {
-            "resolveInfo": null,
-            "reference": "LIonCore_M3_Feature"
-          }
-        ],
-        "LIonCore_M3_Concept_implements": []
-      },
-      "parent": "LIonCore_M3"
-    },
-    {
-      "concept": "LIonCore_M3_Property",
-      "id": "LIonCore_M3_Link_multiple",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "multiple",
-        "LIonCore_M3_Feature_optional": false,
-        "LIonCore_M3_Feature_derived": false
-      },
-      "references": {
-        "LIonCore_M3_Property_type": [
-          {
-            "resolveInfo": null,
-            "reference": "LIonCore_M3_boolean"
-          }
-        ]
-      },
-      "parent": "LIonCore_M3_Link"
-    },
-    {
-      "concept": "LIonCore_M3_Reference",
-      "id": "LIonCore_M3_Link_type",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "concept",
-        "LIonCore_M3_Feature_optional": false,
-        "LIonCore_M3_Feature_derived": false,
-        "LIonCore_M3_Link_multiple": false
-      },
-      "references": {
-        "LIonCore_M3_Link_type": [
-          {
-            "resolveInfo": null,
-            "reference": "LIonCore_M3_FeaturesContainer"
-          }
-        ]
-      },
-      "parent": "LIonCore_M3_Link"
-    },
-    {
-      "concept": "LIonCore_M3_Concept",
-      "id": "LIonCore_M3_Reference",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "Reference",
-        "LIonCore_M3_Concept_abstract": false
-      },
-      "children": {
-        "LIonCore_M3_FeaturesContainer_features": []
-      },
-      "references": {
-        "LIonCore_M3_Concept_extends": [
-          {
-            "resolveInfo": null,
-            "reference": "LIonCore_M3_Link"
-          }
-        ],
-        "LIonCore_M3_Concept_implements": []
-      },
-      "parent": "LIonCore_M3"
-    },
-    {
-      "concept": "LIonCore_M3_Concept",
-      "id": "LIonCore_M3_Property",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "Property",
-        "LIonCore_M3_Concept_abstract": false
-      },
-      "children": {
-        "LIonCore_M3_FeaturesContainer_features": [
-          "LIonCore_M3_Property_type"
-        ]
-      },
-      "references": {
-        "LIonCore_M3_Concept_extends": [
-          {
-            "resolveInfo": null,
-            "reference": "LIonCore_M3_Feature"
-          }
-        ],
-        "LIonCore_M3_Concept_implements": []
-      },
-      "parent": "LIonCore_M3"
-    },
-    {
-      "concept": "LIonCore_M3_Reference",
-      "id": "LIonCore_M3_Property_type",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "concept",
-        "LIonCore_M3_Feature_optional": false,
-        "LIonCore_M3_Feature_derived": false,
-        "LIonCore_M3_Link_multiple": false
-      },
-      "references": {
-        "LIonCore_M3_Link_type": [
-          {
-            "resolveInfo": null,
-            "reference": "LIonCore_M3_DataType"
-          }
-        ]
-      },
-      "parent": "LIonCore_M3_Property"
-    },
-    {
-      "concept": "LIonCore_M3_Concept",
-      "id": "LIonCore_M3_DataType",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "DataType",
-        "LIonCore_M3_Concept_abstract": true
-      },
-      "children": {
-        "LIonCore_M3_FeaturesContainer_features": []
-      },
-      "references": {
-        "LIonCore_M3_Concept_extends": [
-          {
-            "resolveInfo": null,
-            "reference": "LIonCore_M3_MetamodelElement"
-          }
-        ],
-        "LIonCore_M3_Concept_implements": []
-      },
-      "parent": "LIonCore_M3"
-    },
-    {
-      "concept": "LIonCore_M3_Concept",
-      "id": "LIonCore_M3_PrimitiveType",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "PrimitiveType",
-        "LIonCore_M3_Concept_abstract": false
-      },
-      "children": {
-        "LIonCore_M3_FeaturesContainer_features": []
-      },
-      "references": {
-        "LIonCore_M3_Concept_extends": [
-          {
-            "resolveInfo": null,
-            "reference": "LIonCore_M3_DataType"
-          }
-        ],
-        "LIonCore_M3_Concept_implements": []
-      },
-      "parent": "LIonCore_M3"
-    },
-    {
-      "concept": "LIonCore_M3_Concept",
       "id": "LIonCore_M3_Containment",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "Containment",
-        "LIonCore_M3_Concept_abstract": false
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Concept"
       },
-      "children": {
-        "LIonCore_M3_FeaturesContainer_features": []
-      },
-      "references": {
-        "LIonCore_M3_Concept_extends": [
-          {
-            "resolveInfo": null,
-            "reference": "LIonCore_M3_Link"
-          }
-        ],
-        "LIonCore_M3_Concept_implements": []
-      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_abstract"
+          },
+          "value": null
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "Containment"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "LIonCore.M3.Containment"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "LIonCore_M3_Containment"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_FeaturesContainer_features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Link",
+              "reference": "LIonCore_M3_Link"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_implements"
+          },
+          "targets": []
+        }
+      ],
       "parent": "LIonCore_M3"
     },
     {
-      "concept": "LIonCore_M3_Concept",
+      "id": "LIonCore_M3_DataType",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_abstract"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "DataType"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "LIonCore.M3.DataType"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "LIonCore_M3_DataType"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_FeaturesContainer_features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "MetamodelElement",
+              "reference": "LIonCore_M3_MetamodelElement"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_implements"
+          },
+          "targets": []
+        }
+      ],
+      "parent": "LIonCore_M3"
+    },
+    {
       "id": "LIonCore_M3_Enumeration",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "Enumeration",
-        "LIonCore_M3_Concept_abstract": false
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Concept"
       },
-      "children": {
-        "LIonCore_M3_FeaturesContainer_features": [
-          "LIonCore_M3_Enumeration_literals"
-        ]
-      },
-      "references": {
-        "LIonCore_M3_Concept_extends": [
-          {
-            "resolveInfo": null,
-            "reference": "LIonCore_M3_DataType"
-          }
-        ],
-        "LIonCore_M3_Concept_implements": [
-          {
-            "resolveInfo": null,
-            "reference": "LIonCore_M3_NamespaceProvider"
-          }
-        ]
-      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_abstract"
+          },
+          "value": null
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "Enumeration"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "LIonCore.M3.Enumeration"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "LIonCore_M3_Enumeration"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_FeaturesContainer_features"
+          },
+          "children": [
+            "LIonCore_M3_Enumeration_literals"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "DataType",
+              "reference": "LIonCore_M3_DataType"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_implements"
+          },
+          "targets": [
+            {
+              "resolveInfo": "NamespaceProvider",
+              "reference": "LIonCore_M3_NamespaceProvider"
+            }
+          ]
+        }
+      ],
       "parent": "LIonCore_M3"
     },
     {
-      "concept": "LIonCore_M3_Containment",
       "id": "LIonCore_M3_Enumeration_literals",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "literals",
-        "LIonCore_M3_Feature_optional": false,
-        "LIonCore_M3_Feature_derived": false,
-        "LIonCore_M3_Link_multiple": true
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Containment"
       },
-      "references": {
-        "LIonCore_M3_Link_type": [
-          {
-            "resolveInfo": null,
-            "reference": "LIonCore_M3_EnumerationLiteral"
-          }
-        ]
-      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Link_multiple"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "literals"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "LIonCore.M3.Enumeration.literals"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "LIonCore_M3_Enumeration_literals"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Link_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "EnumerationLiteral",
+              "reference": "LIonCore_M3_EnumerationLiteral"
+            }
+          ]
+        }
+      ],
       "parent": "LIonCore_M3_Enumeration"
     },
     {
-      "concept": "LIonCore_M3_Concept",
       "id": "LIonCore_M3_EnumerationLiteral",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "EnumerationLiteral",
-        "LIonCore_M3_Concept_abstract": false
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Concept"
       },
-      "children": {
-        "LIonCore_M3_FeaturesContainer_features": []
-      },
-      "references": {
-        "LIonCore_M3_Concept_extends": [
-          {
-            "resolveInfo": null,
-            "reference": "LIonCore_M3_NamespacedEntity"
-          }
-        ],
-        "LIonCore_M3_Concept_implements": []
-      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_abstract"
+          },
+          "value": null
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "EnumerationLiteral"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "LIonCore.M3.EnumerationLiteral"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "LIonCore_M3_EnumerationLiteral"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_FeaturesContainer_features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "NamespacedEntity",
+              "reference": "LIonCore_M3_NamespacedEntity"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_implements"
+          },
+          "targets": []
+        }
+      ],
       "parent": "LIonCore_M3"
     },
     {
-      "concept": "LIonCore_M3_PrimitiveType",
-      "id": "LIonCore_M3_String",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "String"
+      "id": "LIonCore_M3_Feature",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Concept"
       },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_abstract"
+          },
+          "value": null
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "Feature"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "LIonCore.M3.Feature"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "LIonCore_M3_Feature"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_FeaturesContainer_features"
+          },
+          "children": [
+            "LIonCore_M3_Feature_optional",
+            "LIonCore_M3_Feature_derived"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "NamespacedEntity",
+              "reference": "LIonCore_M3_NamespacedEntity"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_implements"
+          },
+          "targets": [
+            {
+              "resolveInfo": "HasKey",
+              "reference": "LIonCore_M3_HasKey"
+            }
+          ]
+        }
+      ],
       "parent": "LIonCore_M3"
     },
     {
-      "concept": "LIonCore_M3_PrimitiveType",
-      "id": "LIonCore_M3_boolean",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "boolean"
+      "id": "LIonCore_M3_Feature_optional",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Property"
       },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "optional"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "LIonCore.M3.Feature.optional"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "LIonCore_M3_Feature_optional"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Property_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Boolean",
+              "reference": "LIonCore_M3_Boolean"
+            }
+          ]
+        }
+      ],
+      "parent": "LIonCore_M3_Feature"
+    },
+    {
+      "id": "LIonCore_M3_Feature_derived",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "derived"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "LIonCore.M3.Feature.derived"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "LIonCore_M3_Feature_derived"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Property_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Boolean",
+              "reference": "LIonCore_M3_Boolean"
+            }
+          ]
+        }
+      ],
+      "parent": "LIonCore_M3_Feature"
+    },
+    {
+      "id": "LIonCore_M3_FeaturesContainer",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_abstract"
+          },
+          "value": null
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "FeaturesContainer"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "LIonCore.M3.FeaturesContainer"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "LIonCore_M3_FeaturesContainer"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_FeaturesContainer_features"
+          },
+          "children": [
+            "LIonCore_M3_FeaturesContainer_features"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "MetamodelElement",
+              "reference": "LIonCore_M3_MetamodelElement"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_implements"
+          },
+          "targets": [
+            {
+              "resolveInfo": "NamespaceProvider",
+              "reference": "LIonCore_M3_NamespaceProvider"
+            }
+          ]
+        }
+      ],
       "parent": "LIonCore_M3"
     },
     {
-      "concept": "LIonCore_M3_PrimitiveType",
-      "id": "LIonCore_M3_int",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "int"
+      "id": "LIonCore_M3_FeaturesContainer_features",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Containment"
       },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Link_multiple"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "features"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "LIonCore.M3.FeaturesContainer.features"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "LIonCore_M3_FeaturesContainer_features"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Link_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Feature",
+              "reference": "LIonCore_M3_Feature"
+            }
+          ]
+        }
+      ],
+      "parent": "LIonCore_M3_FeaturesContainer"
+    },
+    {
+      "id": "LIonCore_M3_HasKey",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_ConceptInterface"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "HasKey"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "LIonCore.M3.HasKey"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "LIonCore_M3_HasKey"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_FeaturesContainer_features"
+          },
+          "children": [
+            "LIonCore_M3_HasKey_key"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_ConceptInterface_extends"
+          },
+          "targets": []
+        }
+      ],
       "parent": "LIonCore_M3"
     },
     {
-      "concept": "LIonCore_M3_PrimitiveType",
-      "id": "LIonCore_M3_JSON",
-      "properties": {
-        "LIonCore_M3_NamespacedEntity_simpleName": "JSON"
+      "id": "LIonCore_M3_HasKey_key",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Property"
       },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "key"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "LIonCore.M3.HasKey.key"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "LIonCore_M3_HasKey_key"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Property_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LIonCore_M3_String"
+            }
+          ]
+        }
+      ],
+      "parent": "LIonCore_M3_HasKey"
+    },
+    {
+      "id": "LIonCore_M3_Link",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_abstract"
+          },
+          "value": null
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "Link"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "LIonCore.M3.Link"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "LIonCore_M3_Link"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_FeaturesContainer_features"
+          },
+          "children": [
+            "LIonCore_M3_Link_multiple",
+            "LIonCore_M3_Link_type"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Feature",
+              "reference": "LIonCore_M3_Feature"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_implements"
+          },
+          "targets": []
+        }
+      ],
+      "parent": "LIonCore_M3"
+    },
+    {
+      "id": "LIonCore_M3_Link_multiple",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "multiple"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "LIonCore.M3.Link.multiple"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "LIonCore_M3_Link_multiple"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Property_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Boolean",
+              "reference": "LIonCore_M3_Boolean"
+            }
+          ]
+        }
+      ],
+      "parent": "LIonCore_M3_Link"
+    },
+    {
+      "id": "LIonCore_M3_Link_type",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Reference"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Link_multiple"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "type"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "LIonCore.M3.Link.type"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "LIonCore_M3_Link_type"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Link_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "FeaturesContainer",
+              "reference": "LIonCore_M3_FeaturesContainer"
+            }
+          ]
+        }
+      ],
+      "parent": "LIonCore_M3_Link"
+    },
+    {
+      "id": "LIonCore_M3_Metamodel",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_abstract"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "Metamodel"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "LIonCore.M3.Metamodel"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "LIonCore_M3_Metamodel"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_FeaturesContainer_features"
+          },
+          "children": [
+            "LIonCore_M3_Metamodel_name",
+            "LIonCore_M3_Metamodel_version",
+            "LIonCore_M3_Metamodel_dependsOn",
+            "LIonCore_M3_Metamodel_elements"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_extends"
+          },
+          "targets": []
+        },
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_implements"
+          },
+          "targets": [
+            {
+              "resolveInfo": "NamespaceProvider",
+              "reference": "LIonCore_M3_NamespaceProvider"
+            },
+            {
+              "resolveInfo": "HasKey",
+              "reference": "LIonCore_M3_HasKey"
+            }
+          ]
+        }
+      ],
+      "parent": "LIonCore_M3"
+    },
+    {
+      "id": "LIonCore_M3_Metamodel_name",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "name"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "LIonCore.M3.Metamodel.name"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "LIonCore_M3_Metamodel_name"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Property_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LIonCore_M3_String"
+            }
+          ]
+        }
+      ],
+      "parent": "LIonCore_M3_Metamodel"
+    },
+    {
+      "id": "LIonCore_M3_Metamodel_version",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "version"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "LIonCore.M3.Metamodel.version"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "LIonCore_M3_Metamodel_version"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Property_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LIonCore_M3_String"
+            }
+          ]
+        }
+      ],
+      "parent": "LIonCore_M3_Metamodel"
+    },
+    {
+      "id": "LIonCore_M3_Metamodel_dependsOn",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Reference"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Link_multiple"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "dependsOn"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "LIonCore.M3.Metamodel.dependsOn"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "LIonCore_M3_Metamodel_dependsOn"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Link_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Metamodel",
+              "reference": "LIonCore_M3_Metamodel"
+            }
+          ]
+        }
+      ],
+      "parent": "LIonCore_M3_Metamodel"
+    },
+    {
+      "id": "LIonCore_M3_Metamodel_elements",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Containment"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Link_multiple"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "elements"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "LIonCore.M3.Metamodel.elements"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "LIonCore_M3_Metamodel_elements"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Link_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "MetamodelElement",
+              "reference": "LIonCore_M3_MetamodelElement"
+            }
+          ]
+        }
+      ],
+      "parent": "LIonCore_M3_Metamodel"
+    },
+    {
+      "id": "LIonCore_M3_MetamodelElement",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_abstract"
+          },
+          "value": null
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "MetamodelElement"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "LIonCore.M3.MetamodelElement"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "LIonCore_M3_MetamodelElement"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_FeaturesContainer_features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "NamespacedEntity",
+              "reference": "LIonCore_M3_NamespacedEntity"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_implements"
+          },
+          "targets": [
+            {
+              "resolveInfo": "HasKey",
+              "reference": "LIonCore_M3_HasKey"
+            }
+          ]
+        }
+      ],
+      "parent": "LIonCore_M3"
+    },
+    {
+      "id": "LIonCore_M3_NamespacedEntity",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_abstract"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "NamespacedEntity"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "LIonCore.M3.NamespacedEntity"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "LIonCore_M3_NamespacedEntity"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_FeaturesContainer_features"
+          },
+          "children": [
+            "LIonCore_M3_NamespacedEntity_simpleName",
+            "LIonCore_M3_NamespacedEntity_qualifiedName"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_extends"
+          },
+          "targets": []
+        },
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_implements"
+          },
+          "targets": []
+        }
+      ],
+      "parent": "LIonCore_M3"
+    },
+    {
+      "id": "LIonCore_M3_NamespacedEntity_simpleName",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "simpleName"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "LIonCore.M3.NamespacedEntity.simpleName"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "LIonCore_M3_NamespacedEntity_simpleName"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Property_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LIonCore_M3_String"
+            }
+          ]
+        }
+      ],
+      "parent": "LIonCore_M3_NamespacedEntity"
+    },
+    {
+      "id": "LIonCore_M3_NamespacedEntity_qualifiedName",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_derived"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "qualifiedName"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "LIonCore.M3.NamespacedEntity.qualifiedName"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "LIonCore_M3_NamespacedEntity_qualifiedName"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Property_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LIonCore_M3_String"
+            }
+          ]
+        }
+      ],
+      "parent": "LIonCore_M3_NamespacedEntity"
+    },
+    {
+      "id": "LIonCore_M3_NamespaceProvider",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_ConceptInterface"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "NamespaceProvider"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "LIonCore.M3.NamespaceProvider"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "LIonCore_M3_NamespaceProvider"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_FeaturesContainer_features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_ConceptInterface_extends"
+          },
+          "targets": []
+        }
+      ],
+      "parent": "LIonCore_M3"
+    },
+    {
+      "id": "LIonCore_M3_PrimitiveType",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_abstract"
+          },
+          "value": null
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "PrimitiveType"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "LIonCore.M3.PrimitiveType"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "LIonCore_M3_PrimitiveType"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_FeaturesContainer_features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "DataType",
+              "reference": "LIonCore_M3_DataType"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_implements"
+          },
+          "targets": []
+        }
+      ],
+      "parent": "LIonCore_M3"
+    },
+    {
+      "id": "LIonCore_M3_Property",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_abstract"
+          },
+          "value": null
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "Property"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "LIonCore.M3.Property"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "LIonCore_M3_Property"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_FeaturesContainer_features"
+          },
+          "children": [
+            "LIonCore_M3_Property_type"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Feature",
+              "reference": "LIonCore_M3_Feature"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_implements"
+          },
+          "targets": []
+        }
+      ],
+      "parent": "LIonCore_M3"
+    },
+    {
+      "id": "LIonCore_M3_Property_type",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Reference"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Link_multiple"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Feature_derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "type"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "LIonCore.M3.Property.type"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "LIonCore_M3_Property_type"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Link_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "DataType",
+              "reference": "LIonCore_M3_DataType"
+            }
+          ]
+        }
+      ],
+      "parent": "LIonCore_M3_Property"
+    },
+    {
+      "id": "LIonCore_M3_Reference",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "LIonCore_M3_Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_abstract"
+          },
+          "value": null
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_simpleName"
+          },
+          "value": "Reference"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_NamespacedEntity_qualifiedName"
+          },
+          "value": "LIonCore.M3.Reference"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_HasKey_key"
+          },
+          "value": "LIonCore_M3_Reference"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_FeaturesContainer_features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Link",
+              "reference": "LIonCore_M3_Link"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "LIonCore_M3_Concept_implements"
+          },
+          "targets": []
+        }
+      ],
       "parent": "LIonCore_M3"
     }
   ]


### PR DESCRIPTION
With this PR we introduce the LowLevelSerialization. It is intended to load semantically invalid/incoherent chunks and it is an intermediate rappresentation between the "proper" models and metamodels and the JSON representation.

This PR includes an update of all examples.

Some tests are still failing and they will be corrected as part of the remaining PR to finish up #46 