### PR TITLE
Changes necessary to make possible to unserialize ASTs in Kolasu

### DIFF
--- a/core/src/main/java/org/lionweb/lioncore/java/api/CompositeNodeResolver.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/api/CompositeNodeResolver.java
@@ -36,6 +36,6 @@ public class CompositeNodeResolver implements NodeResolver {
 
   @Override
   public String toString() {
-    return "CompositeNodeResolver(" + nodeResolvers +")";
+    return "CompositeNodeResolver(" + nodeResolvers + ")";
   }
 }

--- a/core/src/main/java/org/lionweb/lioncore/java/api/CompositeNodeResolver.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/api/CompositeNodeResolver.java
@@ -33,4 +33,9 @@ public class CompositeNodeResolver implements NodeResolver {
     }
     return null;
   }
+
+  @Override
+  public String toString() {
+    return "CompositeNodeResolver(" + nodeResolvers +")";
+  }
 }

--- a/core/src/main/java/org/lionweb/lioncore/java/api/LocalNodeResolver.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/api/LocalNodeResolver.java
@@ -30,4 +30,9 @@ public class LocalNodeResolver implements NodeResolver {
   public void addAll(@Nonnull List<Node> nodes) {
     nodes.forEach(n -> add(n));
   }
+
+  @Override
+  public String toString() {
+    return "LocalNodeResolver(" + nodes.keySet() + ")";
+  }
 }

--- a/core/src/main/java/org/lionweb/lioncore/java/api/NodeResolver.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/api/NodeResolver.java
@@ -15,7 +15,6 @@ public interface NodeResolver {
   default Node strictlyResolve(String nodeID) {
     Node partial = resolve(nodeID);
     if (partial == null) {
-      System.out.println("RESOLVER " + this);
       throw new UnresolvedNodeException(nodeID);
     } else {
       return partial;

--- a/core/src/main/java/org/lionweb/lioncore/java/api/NodeResolver.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/api/NodeResolver.java
@@ -15,6 +15,7 @@ public interface NodeResolver {
   default Node strictlyResolve(String nodeID) {
     Node partial = resolve(nodeID);
     if (partial == null) {
+      System.out.println("RESOLVER " + this);
       throw new UnresolvedNodeException(nodeID);
     } else {
       return partial;

--- a/core/src/main/java/org/lionweb/lioncore/java/serialization/JsonSerialization.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/serialization/JsonSerialization.java
@@ -249,15 +249,15 @@ public class JsonSerialization {
   // Unserialization
   //
 
-  public List<Node> unserializeToNode(JsonElement jsonElement) {
+  public List<Node> unserializeToNodes(JsonElement jsonElement) {
     SerializedChunk serializationBlock =
         new LowLevelJsonSerialization().unserializeSerializationBlock(jsonElement);
     validateSerializationBlock(serializationBlock);
     return unserializeSerializationBlock(serializationBlock);
   }
 
-  public List<Node> unserializeToNode(String json) {
-    return unserializeToNode(JsonParser.parseString(json));
+  public List<Node> unserializeToNodes(String json) {
+    return unserializeToNodes(JsonParser.parseString(json));
   }
 
   //
@@ -277,39 +277,103 @@ public class JsonSerialization {
     }
   }
 
-  private List<Node> unserializeSerializationBlock(SerializedChunk serializationBlock) {
-    List<Node> nodes =
-        serializationBlock.getNodes().stream()
-            .map(n -> instantiateNodeFromSerialized(n))
-            .collect(Collectors.toList());
-    NodeResolver nodeResolver =
-        new CompositeNodeResolver(new LocalNodeResolver(nodes), this.nodeResolver);
-    serializationBlock.getNodes().stream().forEach(n -> populateNode(n, nodeResolver));
-    return nodes;
+  private List<SerializedNode> sortLeavesFirst(List<SerializedNode> originalList) {
+      List<SerializedNode> sortedList = new ArrayList<>();
+      List<SerializedNode> nodesToSort = new ArrayList<>(originalList);
+      // We create the list going from the roots, to their children and so on, and then we will revert the list
+
+      // We can start by putting at the start all the elements which either have no parent,
+      // or had a parent already added to the list
+      while (sortedList.size() < originalList.size()) {
+          int initialLength = sortedList.size();
+          for (int i=0;i<nodesToSort.size();i++) {
+            SerializedNode n = nodesToSort.get(i);
+            if (n.getParentNodeID() == null || sortedList.stream().anyMatch(sn -> Objects.equals(sn.getID(), n.getParentNodeID()))) {
+                sortedList.add(n);
+                nodesToSort.remove(i);
+                i--;
+            }
+        }
+          if (initialLength == sortedList.size()) {
+              throw new IllegalStateException("Something is not right");
+          }
+      }
+
+      Collections.reverse(sortedList);
+      return sortedList;
   }
 
-  private Node instantiateNodeFromSerialized(SerializedNode serializedNode) {
+  private List<Node> unserializeSerializationBlock(SerializedChunk serializationBlock) {
+    return unserializeNodes(serializationBlock.getNodes());
+  }
+
+    private List<Node> unserializeNodes(List<SerializedNode> serializedNodes) {
+        // We want to unserialize them starting from the leaves. This is useful because in certain
+        // cases we may want to use the children as constructor parameters of the parent
+        List<SerializedNode> sortedSerializedNodes = sortLeavesFirst(serializedNodes);
+        System.out.println("unserializeNodes. sortedSerializedNodes: " + sortedSerializedNodes);
+        Map<String, Node> unserializedNodesByID = new HashMap<>();
+        List<Node> nodes =
+                sortedSerializedNodes.stream()
+                        .map(n -> {
+                            Node instantiatedNode = instantiateNodeFromSerialized(n, unserializedNodesByID);
+                            unserializedNodesByID.put(n.getID(), instantiatedNode);
+                            return instantiatedNode;
+                        })
+                        .collect(Collectors.toList());
+        System.out.println("unserializeNodes. Nodes: " + nodes);
+        System.out.println("unserializeNodes. Nodes IDS: " + nodes.stream().map(n -> n.getID()).collect(Collectors.joining(", ")));
+        NodeResolver nodeResolver =
+                new CompositeNodeResolver(new MapBasedResolver(unserializedNodesByID), this.nodeResolver);
+        serializedNodes.stream().forEach(n -> populateNode(n, nodeResolver));
+
+        // We want the nodes returned to be sorted as the original serializedNodes
+        List<Node> nodesWithOriginalSorting = new LinkedList<>();
+        serializedNodes.forEach(sn -> {
+            Optional<Node> node = nodes.stream().filter(n -> n.getID().equals(sn.getID())).findFirst();
+            if (!node.isPresent()) {
+                throw new IllegalStateException("Unable to find node with ID " + sn.getID()+". Known IDs: " + nodes.stream().map(n -> n.getID()).collect(Collectors.joining(", ")));
+            }
+            nodesWithOriginalSorting.add(node.get());
+        });
+
+        return nodesWithOriginalSorting;
+    }
+
+  private Node instantiateNodeFromSerialized(SerializedNode serializedNode, Map<String, Node> unserializedNodesByID) {
     Concept concept = getConceptResolver().resolveConcept(serializedNode.getConcept());
-    Node node = getNodeInstantiator().instantiate(concept, serializedNode);
-    serializedNode
-        .getProperties()
-        .forEach(
-            serializedPropertyValue -> {
-              Property property =
-                  concept.getPropertyByMetaPointer(serializedPropertyValue.getMetaPointer());
-              Objects.requireNonNull(
-                  property,
-                  "Property with metaPointer "
-                      + serializedPropertyValue.getMetaPointer()
-                      + " not found in concept "
-                      + concept
-                      + ". SerializedNode: "
-                      + serializedNode);
-              Object unserializedValue =
-                  primitiveValuesSerialization.unserialize(
-                      property.getType().getID(), serializedPropertyValue.getValue());
-              node.setPropertyValue(property, unserializedValue);
-            });
+    Map<Property, Object> propertiesValues = new HashMap<>();
+      serializedNode
+              .getProperties()
+              .forEach(
+                      serializedPropertyValue -> {
+                          Property property =
+                                  concept.getPropertyByMetaPointer(serializedPropertyValue.getMetaPointer());
+                          Objects.requireNonNull(
+                                  property,
+                                  "Property with metaPointer "
+                                          + serializedPropertyValue.getMetaPointer()
+                                          + " not found in concept "
+                                          + concept
+                                          + ". SerializedNode: "
+                                          + serializedNode);
+                          Object unserializedValue =
+                                  primitiveValuesSerialization.unserialize(
+                                          property.getType().getID(), serializedPropertyValue.getValue());
+                          propertiesValues.put(property, unserializedValue);
+                      });
+    Node node = getNodeInstantiator().instantiate(concept, serializedNode, unserializedNodesByID, propertiesValues);
+    propertiesValues.entrySet().forEach(pv -> {
+        Object unserializedValue = pv.getValue();
+        Property property = pv.getKey();
+      // Avoiding calling setters, in case the value has been already set at construction time
+
+      if (!property.isDerived() && !Objects.equals(unserializedValue, node.getPropertyValue(property))) {
+          node.setPropertyValue(property, unserializedValue);
+      }
+    });
+    nodeResolver.add(node);
+
     return node;
   }
 
@@ -334,13 +398,10 @@ public class JsonSerialization {
               Objects.requireNonNull(
                   serializedContainmentValue.getValue(),
                   "The containment value should not be null");
-              serializedContainmentValue
-                  .getValue()
-                  .forEach(
-                      childNodeID -> {
-                        Node child = nodeResolver.strictlyResolve(childNodeID);
-                        node.addChild(containment, child);
-                      });
+              List<Node> unserializedValue = serializedContainmentValue.getValue().stream().map(childNodeID -> nodeResolver.strictlyResolve(childNodeID)).collect(Collectors.toList());
+            if (!containment.isDerived() && !Objects.equals(unserializedValue, node.getChildren(containment))) {
+                unserializedValue.forEach(child -> node.addChild(containment, child));
+            }
             });
   }
 

--- a/core/src/main/java/org/lionweb/lioncore/java/serialization/JsonSerialization.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/serialization/JsonSerialization.java
@@ -277,10 +277,10 @@ public class JsonSerialization {
     }
   }
 
-    /**
-     * This method returned a sorted version of the original list, so that leaves nodes comes first, or in other
-     * words that a parent never precedes its children.
-     */
+  /**
+   * This method returned a sorted version of the original list, so that leaves nodes comes first,
+   * or in other words that a parent never precedes its children.
+   */
   private List<SerializedNode> sortLeavesFirst(List<SerializedNode> originalList) {
     List<SerializedNode> sortedList = new ArrayList<>();
     List<SerializedNode> nodesToSort = new ArrayList<>(originalList);
@@ -302,8 +302,8 @@ public class JsonSerialization {
         }
       }
       if (initialLength == sortedList.size()) {
-        throw new IllegalStateException("Something is not right: we are unable to complete sorting the list "
-                + originalList);
+        throw new IllegalStateException(
+            "Something is not right: we are unable to complete sorting the list " + originalList);
       }
     }
 
@@ -319,18 +319,18 @@ public class JsonSerialization {
     // We want to unserialize the nodes starting from the leaves. This is useful because in certain
     // cases we may want to use the children as constructor parameters of the parent
     List<SerializedNode> sortedSerializedNodes = sortLeavesFirst(serializedNodes);
-      if (sortedSerializedNodes.size() != serializedNodes.size()) {
-          throw new IllegalStateException();
-      }
+    if (sortedSerializedNodes.size() != serializedNodes.size()) {
+      throw new IllegalStateException();
+    }
     Map<String, Node> unserializedNodesByID = new HashMap<>();
-   sortedSerializedNodes.stream()
-            .forEach(
-                n -> {
-                  Node instantiatedNode = instantiateNodeFromSerialized(n, unserializedNodesByID);
-                  unserializedNodesByID.put(n.getID(), instantiatedNode);
-                });
+    sortedSerializedNodes.stream()
+        .forEach(
+            n -> {
+              Node instantiatedNode = instantiateNodeFromSerialized(n, unserializedNodesByID);
+              unserializedNodesByID.put(n.getID(), instantiatedNode);
+            });
     if (sortedSerializedNodes.size() != unserializedNodesByID.size()) {
-        throw new IllegalStateException();
+      throw new IllegalStateException();
     }
     NodeResolver nodeResolver =
         new CompositeNodeResolver(new MapBasedResolver(unserializedNodesByID), this.nodeResolver);
@@ -340,7 +340,7 @@ public class JsonSerialization {
     List<Node> nodesWithOriginalSorting = new LinkedList<>();
     serializedNodes.forEach(
         sn -> {
-            Node node = unserializedNodesByID.get(sn.getID());
+          Node node = unserializedNodesByID.get(sn.getID());
           if (node == null) {
             throw new IllegalStateException(
                 "Unable to find node with ID "
@@ -358,7 +358,8 @@ public class JsonSerialization {
       SerializedNode serializedNode, Map<String, Node> unserializedNodesByID) {
     Concept concept = getConceptResolver().resolveConcept(serializedNode.getConcept());
 
-    // We prepare all the properties values and pass them to instantiator, as it could use them to build the node
+    // We prepare all the properties values and pass them to instantiator, as it could use them to
+    // build the node
     Map<Property, Object> propertiesValues = new HashMap<>();
     serializedNode
         .getProperties()

--- a/core/src/main/java/org/lionweb/lioncore/java/serialization/JsonSerialization.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/serialization/JsonSerialization.java
@@ -137,6 +137,8 @@ public class JsonSerialization {
                     allNodes.add(n);
                     nodesIDs.add(n.getID());
                   }
+                } else {
+                    allNodes.add(n);
                 }
               });
     }

--- a/core/src/main/java/org/lionweb/lioncore/java/serialization/JsonSerialization.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/serialization/JsonSerialization.java
@@ -317,8 +317,10 @@ public class JsonSerialization {
         }
       }
       if (initialLength == sortedList.size()) {
-        throw new IllegalStateException(
-            "Something is not right: we are unable to complete sorting the list " + originalList);
+        throw new UnserializationException(
+            "Something is not right: we are unable to complete sorting the list "
+                + originalList
+                + ". Probably there is a containment loop");
       }
     }
 
@@ -476,7 +478,7 @@ public class JsonSerialization {
                       entry -> {
                         Node referred = nodeResolver.resolve(entry.getReference());
                         if (entry.getReference() != null && referred == null) {
-                          throw new IllegalArgumentException(
+                          throw new UnserializationException(
                               "Unable to resolve reference to "
                                   + entry.getReference()
                                   + " for feature "

--- a/core/src/main/java/org/lionweb/lioncore/java/serialization/JsonSerialization.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/serialization/JsonSerialization.java
@@ -138,7 +138,7 @@ public class JsonSerialization {
                     nodesIDs.add(n.getID());
                   }
                 } else {
-                    allNodes.add(n);
+                  allNodes.add(n);
                 }
               });
     }
@@ -296,7 +296,8 @@ public class JsonSerialization {
     // the list
 
     // Nodes with null IDs are ambiguous but they cannot be the children of any node: they can just
-    // be parent of other nodes, so we put all of them at the start (so they end up at the end when we reverse
+    // be parent of other nodes, so we put all of them at the start (so they end up at the end when
+    // we reverse
     // the list)
     nodesToSort.stream().filter(n -> n.getID() == null).forEach(n -> sortedList.add(n));
     nodesToSort.removeAll(sortedList);
@@ -349,14 +350,22 @@ public class JsonSerialization {
               serializedToNodeMap.put(n, instantiatedNode);
             });
     if (sortedSerializedNodes.size() != serializedToNodeMap.size()) {
-      throw new IllegalStateException("We got " + sortedSerializedNodes.size() + " nodes to unserialize, but we unserialized " + serializedToNodeMap.size());
+      throw new IllegalStateException(
+          "We got "
+              + sortedSerializedNodes.size()
+              + " nodes to unserialize, but we unserialized "
+              + serializedToNodeMap.size());
     }
     NodeResolver nodeResolver =
         new CompositeNodeResolver(new MapBasedResolver(unserializedNodesByID), this.nodeResolver);
-    serializedNodes.stream().forEach(n -> populateNode(n, serializedToNodeMap.get(n), nodeResolver));
+    serializedNodes.stream()
+        .forEach(n -> populateNode(n, serializedToNodeMap.get(n), nodeResolver));
 
     // We want the nodes returned to be sorted as the original serializedNodes
-    List<Node> nodesWithOriginalSorting = serializedNodes.stream().map(sn -> serializedToNodeMap.get(sn)).collect(Collectors.toList());
+    List<Node> nodesWithOriginalSorting =
+        serializedNodes.stream()
+            .map(sn -> serializedToNodeMap.get(sn))
+            .collect(Collectors.toList());
     return nodesWithOriginalSorting;
   }
 

--- a/core/src/main/java/org/lionweb/lioncore/java/serialization/JsonSerialization.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/serialization/JsonSerialization.java
@@ -295,6 +295,12 @@ public class JsonSerialization {
     // We create the list going from the roots, to their children and so on, and then we will revert
     // the list
 
+    // Nodes with null IDs are ambiguous but they cannot be the children of any node: they can just
+    // be parent of other nodes, so we put all of them at the start (so they end up at the end when we reverse
+    // the list)
+    nodesToSort.stream().filter(n -> n.getID() == null).forEach(n -> sortedList.add(n));
+    nodesToSort.removeAll(sortedList);
+
     // We can start by putting at the start all the elements which either have no parent,
     // or had a parent already added to the list
     while (sortedList.size() < originalList.size()) {

--- a/core/src/main/java/org/lionweb/lioncore/java/serialization/LowLevelJsonSerialization.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/serialization/LowLevelJsonSerialization.java
@@ -56,6 +56,7 @@ public class LowLevelJsonSerialization {
         "serializationFormatVersion", serializedChunk.getSerializationFormatVersion());
 
     JsonArray metamodels = new JsonArray();
+    serializedChunk.getMetamodels().forEach(m -> metamodels.add(serializeToJsonElement(m)));
     topLevel.add("metamodels", metamodels);
 
     JsonArray nodes = new JsonArray();
@@ -180,6 +181,13 @@ public class LowLevelJsonSerialization {
     jsonObject.addProperty("metamodel", metapointer.getMetamodel());
     jsonObject.addProperty("version", metapointer.getVersion());
     jsonObject.addProperty("key", metapointer.getKey());
+    return jsonObject;
+  }
+
+  private JsonElement serializeToJsonElement(MetamodelKeyVersion metamodelKeyVersion) {
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty("version", metamodelKeyVersion.getVersion());
+    jsonObject.addProperty("key", metamodelKeyVersion.getKey());
     return jsonObject;
   }
 

--- a/core/src/main/java/org/lionweb/lioncore/java/serialization/LowLevelJsonSerialization.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/serialization/LowLevelJsonSerialization.java
@@ -166,6 +166,8 @@ public class LowLevelJsonSerialization {
                 try {
                   SerializedNode node = unserializeNode(element);
                   serializedChunk.addNode(node);
+                } catch (UnserializationException e) {
+                  throw new UnserializationException("Issue while unserializing nodes", e);
                 } catch (Exception e) {
                   throw new RuntimeException("Issue while unserializing " + element, e);
                 }
@@ -221,7 +223,7 @@ public class LowLevelJsonSerialization {
           serializedNode.addContainmentValue(
               new SerializedContainmentValue(
                   tryToGetMetaPointerProperty(childrenJO, "containment"),
-                  tryToGetArrayOfStringsProperty(childrenJO, "children")));
+                  tryToGetArrayOfIDs(childrenJO, "children")));
         });
 
     JsonArray references = jsonObject.get("references").getAsJsonArray();

--- a/core/src/main/java/org/lionweb/lioncore/java/serialization/MapBasedResolver.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/serialization/MapBasedResolver.java
@@ -1,0 +1,30 @@
+package org.lionweb.lioncore.java.serialization;
+
+import org.lionweb.lioncore.java.api.NodeResolver;
+import org.lionweb.lioncore.java.model.Node;
+
+import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This is used only during unserialization. Some nodes could be an ID that depends on their position, so until
+ * we place them they could be a temporarily wrong ID.
+ */
+class MapBasedResolver implements NodeResolver  {
+    private Map<String, Node> nodesByID = new HashMap<>();
+
+    public MapBasedResolver() {
+
+    }
+
+    public MapBasedResolver(Map<String, Node> nodesByID) {
+        this.nodesByID.putAll(nodesByID);
+    }
+
+    @Nullable
+    @Override
+    public Node resolve(String nodeID) {
+        return nodesByID.get(nodeID);
+    }
+}

--- a/core/src/main/java/org/lionweb/lioncore/java/serialization/MapBasedResolver.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/serialization/MapBasedResolver.java
@@ -1,30 +1,27 @@
 package org.lionweb.lioncore.java.serialization;
 
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
 import org.lionweb.lioncore.java.api.NodeResolver;
 import org.lionweb.lioncore.java.model.Node;
 
-import javax.annotation.Nullable;
-import java.util.HashMap;
-import java.util.Map;
-
 /**
- * This is used only during unserialization. Some nodes could be an ID that depends on their position, so until
- * we place them they could be a temporarily wrong ID.
+ * This is used only during unserialization. Some nodes could be an ID that depends on their
+ * position, so until we place them they could be a temporarily wrong ID.
  */
-class MapBasedResolver implements NodeResolver  {
-    private Map<String, Node> nodesByID = new HashMap<>();
+class MapBasedResolver implements NodeResolver {
+  private Map<String, Node> nodesByID = new HashMap<>();
 
-    public MapBasedResolver() {
+  public MapBasedResolver() {}
 
-    }
+  public MapBasedResolver(Map<String, Node> nodesByID) {
+    this.nodesByID.putAll(nodesByID);
+  }
 
-    public MapBasedResolver(Map<String, Node> nodesByID) {
-        this.nodesByID.putAll(nodesByID);
-    }
-
-    @Nullable
-    @Override
-    public Node resolve(String nodeID) {
-        return nodesByID.get(nodeID);
-    }
+  @Nullable
+  @Override
+  public Node resolve(String nodeID) {
+    return nodesByID.get(nodeID);
+  }
 }

--- a/core/src/main/java/org/lionweb/lioncore/java/serialization/NodeInstantiator.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/serialization/NodeInstantiator.java
@@ -1,15 +1,12 @@
 package org.lionweb.lioncore.java.serialization;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import org.lionweb.lioncore.java.metamodel.*;
 import org.lionweb.lioncore.java.model.Node;
 import org.lionweb.lioncore.java.model.impl.DynamicNode;
 import org.lionweb.lioncore.java.self.LionCore;
 import org.lionweb.lioncore.java.serialization.data.SerializedNode;
-
-import javax.annotation.Nullable;
 
 /**
  * This knows how to instantiate a Node, given the information provided by the unserialization
@@ -18,8 +15,11 @@ import javax.annotation.Nullable;
 public class NodeInstantiator {
 
   public interface ConceptSpecificNodeInstantiator<T extends Node> {
-    T instantiate(Concept concept, SerializedNode serializedNode,
-                  Map<String, Node> unserializedNodesByID, Map<Property, Object> propertiesValues);
+    T instantiate(
+        Concept concept,
+        SerializedNode serializedNode,
+        Map<String, Node> unserializedNodesByID,
+        Map<Property, Object> propertiesValues);
   }
 
   private Map<String, ConceptSpecificNodeInstantiator<?>> customUnserializers = new HashMap<>();
@@ -32,15 +32,23 @@ public class NodeInstantiator {
 
   public NodeInstantiator enableDynamicNodes() {
     defaultNodeUnserializer =
-        (concept, serializedNode, unserializedNodesByID, propertiesValues) -> new DynamicNode(serializedNode.getID(), concept);
+        (concept, serializedNode, unserializedNodesByID, propertiesValues) ->
+            new DynamicNode(serializedNode.getID(), concept);
     return this;
   }
 
-  public Node instantiate(Concept concept, SerializedNode serializedNode, Map<String, Node> unserializedNodesByID, Map<Property, Object> propertiesValues) {
+  public Node instantiate(
+      Concept concept,
+      SerializedNode serializedNode,
+      Map<String, Node> unserializedNodesByID,
+      Map<Property, Object> propertiesValues) {
     if (customUnserializers.containsKey(concept.getID())) {
-      return customUnserializers.get(concept.getID()).instantiate(concept, serializedNode, unserializedNodesByID, propertiesValues);
+      return customUnserializers
+          .get(concept.getID())
+          .instantiate(concept, serializedNode, unserializedNodesByID, propertiesValues);
     } else {
-      return defaultNodeUnserializer.instantiate(concept, serializedNode, unserializedNodesByID, propertiesValues);
+      return defaultNodeUnserializer.instantiate(
+          concept, serializedNode, unserializedNodesByID, propertiesValues);
     }
   }
 
@@ -53,31 +61,39 @@ public class NodeInstantiator {
   public void registerLionCoreCustomUnserializers() {
     customUnserializers.put(
         LionCore.getMetamodel().getID(),
-        (concept, serializedNode, unserializedNodesByID, propertiesValues) -> new Metamodel().setID(serializedNode.getID()));
+        (concept, serializedNode, unserializedNodesByID, propertiesValues) ->
+            new Metamodel().setID(serializedNode.getID()));
     customUnserializers.put(
         LionCore.getConcept().getID(),
-        (concept, serializedNode, unserializedNodesByID, propertiesValues) -> new Concept((String) null).setID(serializedNode.getID()));
+        (concept, serializedNode, unserializedNodesByID, propertiesValues) ->
+            new Concept((String) null).setID(serializedNode.getID()));
     customUnserializers.put(
         LionCore.getConceptInterface().getID(),
         (concept, serializedNode, unserializedNodesByID, propertiesValues) ->
             new ConceptInterface((String) null).setID(serializedNode.getID()));
     customUnserializers.put(
         LionCore.getProperty().getID(),
-        (concept, serializedNode, unserializedNodesByID, propertiesValues) -> new Property(null, null, serializedNode.getID()));
+        (concept, serializedNode, unserializedNodesByID, propertiesValues) ->
+            new Property(null, null, serializedNode.getID()));
     customUnserializers.put(
         LionCore.getReference().getID(),
-        (concept, serializedNode, unserializedNodesByID, propertiesValues) -> new Reference(null, serializedNode.getID()));
+        (concept, serializedNode, unserializedNodesByID, propertiesValues) ->
+            new Reference(null, serializedNode.getID()));
     customUnserializers.put(
         LionCore.getContainment().getID(),
-        (concept, serializedNode, unserializedNodesByID, propertiesValues) -> new Containment(null, serializedNode.getID()));
+        (concept, serializedNode, unserializedNodesByID, propertiesValues) ->
+            new Containment(null, serializedNode.getID()));
     customUnserializers.put(
         LionCore.getPrimitiveType().getID(),
-        (concept, serializedNode, unserializedNodesByID, propertiesValues) -> new PrimitiveType(serializedNode.getID()));
+        (concept, serializedNode, unserializedNodesByID, propertiesValues) ->
+            new PrimitiveType(serializedNode.getID()));
     customUnserializers.put(
         LionCore.getEnumeration().getID(),
-        (concept, serializedNode, unserializedNodesByID, propertiesValues) -> new Enumeration().setID(serializedNode.getID()));
+        (concept, serializedNode, unserializedNodesByID, propertiesValues) ->
+            new Enumeration().setID(serializedNode.getID()));
     customUnserializers.put(
         LionCore.getEnumerationLiteral().getID(),
-        (concept, serializedNode, unserializedNodesByID, propertiesValues) -> new EnumerationLiteral().setID(serializedNode.getID()));
+        (concept, serializedNode, unserializedNodesByID, propertiesValues) ->
+            new EnumerationLiteral().setID(serializedNode.getID()));
   }
 }

--- a/core/src/main/java/org/lionweb/lioncore/java/serialization/SerializationUtils.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/serialization/SerializationUtils.java
@@ -56,14 +56,23 @@ class SerializationUtils {
   }
 
   @Nullable
-  static List<String> tryToGetArrayOfStringsProperty(JsonObject jsonObject, String propertyName) {
+  static List<String> tryToGetArrayOfIDs(JsonObject jsonObject, String propertyName) {
     if (!jsonObject.has(propertyName)) {
       return null;
     }
     JsonElement value = jsonObject.get(propertyName);
     if (value.isJsonArray()) {
       JsonArray valueJA = value.getAsJsonArray();
-      return valueJA.asList().stream().map(e -> e.getAsString()).collect(Collectors.toList());
+      return valueJA.asList().stream()
+          .map(
+              e -> {
+                if (e.isJsonNull()) {
+                  throw new UnserializationException(
+                      "Unable to unserialize child identified by Null ID");
+                }
+                return e.getAsString();
+              })
+          .collect(Collectors.toList());
     } else {
       return null;
     }

--- a/core/src/main/java/org/lionweb/lioncore/java/serialization/UnserializationException.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/serialization/UnserializationException.java
@@ -1,0 +1,11 @@
+package org.lionweb.lioncore.java.serialization;
+
+public class UnserializationException extends RuntimeException {
+  public UnserializationException(String message) {
+    super("Problem during unserialization: " + message);
+  }
+
+  public UnserializationException(String message, UnserializationException e) {
+    super("Problem during unserialization: " + message, e);
+  }
+}

--- a/core/src/test/java/org/lionweb/lioncore/java/serialization/JsonSerializationTest.java
+++ b/core/src/test/java/org/lionweb/lioncore/java/serialization/JsonSerializationTest.java
@@ -246,6 +246,6 @@ public class JsonSerializationTest extends SerializationTest {
     JsonElement serialized = js.serializeNodesToJsonElement(il4, il1, sum1, il2, sum2, il3);
     prepareUnserializationOfSimpleMath(js);
     List<Node> unserialized = js.unserializeToNodes(serialized);
-    assertEquals(Arrays.asList(sum1, il1, il2, sum2, il3, il4), unserialized);
+    assertEquals(Arrays.asList(il4, il1, sum1, il2, sum2, il3), unserialized);
   }
 }

--- a/core/src/test/java/org/lionweb/lioncore/java/serialization/JsonSerializationTest.java
+++ b/core/src/test/java/org/lionweb/lioncore/java/serialization/JsonSerializationTest.java
@@ -118,7 +118,7 @@ public class JsonSerializationTest extends SerializationTest {
         this.getClass().getResourceAsStream("/serialization/TestLang-metamodel.json");
     JsonElement jsonElement = JsonParser.parseReader(new InputStreamReader(inputStream));
     JsonSerialization jsonSerialization = JsonSerialization.getStandardSerialization();
-    List<Node> unserializedNodes = jsonSerialization.unserializeToNode(jsonElement);
+    List<Node> unserializedNodes = jsonSerialization.unserializeToNodes(jsonElement);
 
     Enumeration testEnumeration1 =
         (Enumeration)

--- a/core/src/test/java/org/lionweb/lioncore/java/serialization/JsonSerializationTest.java
+++ b/core/src/test/java/org/lionweb/lioncore/java/serialization/JsonSerializationTest.java
@@ -268,4 +268,17 @@ public class JsonSerializationTest extends SerializationTest {
     List<Node> unserialized = js.unserializeToNodes(serialized);
     assertEquals(Arrays.asList(il4, il1, sum1, il2, sum2, il3), unserialized);
   }
+
+  // We should get a RuntimeException as we are unable to reassign the child with null ID
+  @Test(expected = UnserializationException.class)
+  public void deserializeChildrenWithNullID() {
+    IntLiteral il1 = new IntLiteral(1, "int_1");
+    IntLiteral il2 = new IntLiteral(2, null);
+    Sum sum1 = new Sum(il1, il2, null);
+    JsonSerialization js = JsonSerialization.getStandardSerialization();
+    JsonElement serialized = js.serializeNodesToJsonElement(sum1, il1, il2);
+    prepareUnserializationOfSimpleMath(js);
+    List<Node> unserialized = js.unserializeToNodes(serialized);
+    assertEquals(Arrays.asList(sum1, il1, il2), unserialized);
+  }
 }

--- a/core/src/test/java/org/lionweb/lioncore/java/serialization/JsonSerializationTest.java
+++ b/core/src/test/java/org/lionweb/lioncore/java/serialization/JsonSerializationTest.java
@@ -269,7 +269,7 @@ public class JsonSerializationTest extends SerializationTest {
     assertEquals(Arrays.asList(il4, il1, sum1, il2, sum2, il3), unserialized);
   }
 
-  // We should get a RuntimeException as we are unable to reassign the child with null ID
+  // We should get a UnserializationException as we are unable to reassign the child with null ID
   @Test(expected = UnserializationException.class)
   public void deserializeChildrenWithNullID() {
     IntLiteral il1 = new IntLiteral(1, "int_1");

--- a/core/src/test/java/org/lionweb/lioncore/java/serialization/LibraryMetamodel.java
+++ b/core/src/test/java/org/lionweb/lioncore/java/serialization/LibraryMetamodel.java
@@ -24,7 +24,7 @@ public class LibraryMetamodel {
         LibraryMetamodel.class.getResourceAsStream("/serialization/library-metamodel.json");
     JsonElement jsonElement = JsonParser.parseReader(new InputStreamReader(inputStream));
     JsonSerialization jsonSerialization = JsonSerialization.getStandardSerialization();
-    List<Node> unserializedNodes = jsonSerialization.unserializeToNode(jsonElement);
+    List<Node> unserializedNodes = jsonSerialization.unserializeToNodes(jsonElement);
     LIBRARY_MM =
         unserializedNodes.stream()
             .filter(e -> e instanceof Metamodel)

--- a/core/src/test/java/org/lionweb/lioncore/java/serialization/SerializationOfLibraryTest.java
+++ b/core/src/test/java/org/lionweb/lioncore/java/serialization/SerializationOfLibraryTest.java
@@ -24,7 +24,7 @@ public class SerializationOfLibraryTest extends SerializationTest {
         this.getClass().getResourceAsStream("/serialization/library-metamodel.json");
     JsonElement jsonElement = JsonParser.parseReader(new InputStreamReader(inputStream));
     JsonSerialization jsonSerialization = JsonSerialization.getStandardSerialization();
-    List<Node> unserializedNodes = jsonSerialization.unserializeToNode(jsonElement);
+    List<Node> unserializedNodes = jsonSerialization.unserializeToNodes(jsonElement);
 
     Concept library = conceptByID(unserializedNodes, "library-Library");
     Property libraryName = library.getPropertyByName("name");
@@ -51,7 +51,7 @@ public class SerializationOfLibraryTest extends SerializationTest {
         this.getClass().getResourceAsStream("/serialization/library-metamodel.json");
     JsonElement jsonElement = JsonParser.parseReader(new InputStreamReader(inputStream));
     JsonSerialization jsonSerialization = JsonSerialization.getStandardSerialization();
-    List<Node> unserializedNodes = jsonSerialization.unserializeToNode(jsonElement);
+    List<Node> unserializedNodes = jsonSerialization.unserializeToNodes(jsonElement);
     JsonElement reserialized =
         jsonSerialization.serializeTreeToJsonElement(unserializedNodes.get(0));
     assertEquivalentLionWebJson(jsonElement.getAsJsonObject(), reserialized.getAsJsonObject());

--- a/core/src/test/java/org/lionweb/lioncore/java/serialization/SerializationOfLionCoreTest.java
+++ b/core/src/test/java/org/lionweb/lioncore/java/serialization/SerializationOfLionCoreTest.java
@@ -139,7 +139,7 @@ public class SerializationOfLionCoreTest extends SerializationTest {
     InputStream inputStream = this.getClass().getResourceAsStream("/serialization/lioncore.json");
     JsonElement jsonElement = JsonParser.parseReader(new InputStreamReader(inputStream));
     JsonSerialization jsonSerialization = JsonSerialization.getStandardSerialization();
-    List<Node> unserializedNodes = jsonSerialization.unserializeToNode(jsonElement);
+    List<Node> unserializedNodes = jsonSerialization.unserializeToNodes(jsonElement);
 
     Metamodel lioncore = (Metamodel) unserializedNodes.get(0);
     assertEquals(LionCore.getMetamodel(), lioncore.getConcept());
@@ -177,7 +177,7 @@ public class SerializationOfLionCoreTest extends SerializationTest {
     jsonSerialization
         .getPrimitiveValuesSerialization()
         .registerLionBuiltinsPrimitiveSerializersAndUnserializers();
-    List<Node> unserializedNodes = jsonSerialization.unserializeToNode(jsonElement);
+    List<Node> unserializedNodes = jsonSerialization.unserializeToNodes(jsonElement);
 
     DynamicNode lioncore = (DynamicNode) unserializedNodes.get(0);
     assertEquals(LionCore.getMetamodel(), lioncore.getConcept());
@@ -210,6 +210,6 @@ public class SerializationOfLionCoreTest extends SerializationTest {
     jsonSerialization
         .getPrimitiveValuesSerialization()
         .registerLionBuiltinsPrimitiveSerializersAndUnserializers();
-    jsonSerialization.unserializeToNode(jsonElement);
+    jsonSerialization.unserializeToNodes(jsonElement);
   }
 }

--- a/core/src/test/java/org/lionweb/lioncore/java/serialization/SerializationOfPrimitiveValuesTest.java
+++ b/core/src/test/java/org/lionweb/lioncore/java/serialization/SerializationOfPrimitiveValuesTest.java
@@ -146,7 +146,8 @@ public class SerializationOfPrimitiveValuesTest extends SerializationTest {
         .getNodeInstantiator()
         .registerCustomUnserializer(
             MyNodeWithProperties.CONCEPT.getID(),
-            (concept, serializedNode, unserializedNodesByID, propertiesValue) -> new MyNodeWithProperties(serializedNode.getID()));
+            (concept, serializedNode, unserializedNodesByID, propertiesValue) ->
+                new MyNodeWithProperties(serializedNode.getID()));
     List<Node> unserialized = jsonSerialization.unserializeToNodes(serialized);
     assertEquals(Arrays.asList(node), unserialized);
   }
@@ -280,7 +281,8 @@ public class SerializationOfPrimitiveValuesTest extends SerializationTest {
         .getNodeInstantiator()
         .registerCustomUnserializer(
             MyNodeWithProperties.CONCEPT.getID(),
-            (concept, serializedNode, unserializedNodesByID, propertiesValue) -> new MyNodeWithProperties(serializedNode.getID()));
+            (concept, serializedNode, unserializedNodesByID, propertiesValue) ->
+                new MyNodeWithProperties(serializedNode.getID()));
     List<Node> unserialized = jsonSerialization.unserializeToNodes(serialized);
     assertEquals(Arrays.asList(node), unserialized);
   }
@@ -414,7 +416,8 @@ public class SerializationOfPrimitiveValuesTest extends SerializationTest {
         .getNodeInstantiator()
         .registerCustomUnserializer(
             MyNodeWithProperties.CONCEPT.getID(),
-            (concept, serializedNode, unserializedNodesByID, propertiesValue) -> new MyNodeWithProperties(serializedNode.getID()));
+            (concept, serializedNode, unserializedNodesByID, propertiesValue) ->
+                new MyNodeWithProperties(serializedNode.getID()));
     List<Node> unserialized = jsonSerialization.unserializeToNodes(serialized);
     assertEquals(Arrays.asList(node), unserialized);
   }
@@ -554,7 +557,8 @@ public class SerializationOfPrimitiveValuesTest extends SerializationTest {
         .getNodeInstantiator()
         .registerCustomUnserializer(
             MyNodeWithProperties.CONCEPT.getID(),
-            (concept, serializedNode, unserializedNodesByID, propertiesValue) -> new MyNodeWithProperties(serializedNode.getID()));
+            (concept, serializedNode, unserializedNodesByID, propertiesValue) ->
+                new MyNodeWithProperties(serializedNode.getID()));
     List<Node> unserialized = jsonSerialization.unserializeToNodes(serialized);
     assertEquals(Arrays.asList(node), unserialized);
   }

--- a/core/src/test/java/org/lionweb/lioncore/java/serialization/SerializationOfPrimitiveValuesTest.java
+++ b/core/src/test/java/org/lionweb/lioncore/java/serialization/SerializationOfPrimitiveValuesTest.java
@@ -146,8 +146,8 @@ public class SerializationOfPrimitiveValuesTest extends SerializationTest {
         .getNodeInstantiator()
         .registerCustomUnserializer(
             MyNodeWithProperties.CONCEPT.getID(),
-            (concept, serializedNode) -> new MyNodeWithProperties(serializedNode.getID()));
-    List<Node> unserialized = jsonSerialization.unserializeToNode(serialized);
+            (concept, serializedNode, unserializedNodesByID, propertiesValue) -> new MyNodeWithProperties(serializedNode.getID()));
+    List<Node> unserialized = jsonSerialization.unserializeToNodes(serialized);
     assertEquals(Arrays.asList(node), unserialized);
   }
 
@@ -280,8 +280,8 @@ public class SerializationOfPrimitiveValuesTest extends SerializationTest {
         .getNodeInstantiator()
         .registerCustomUnserializer(
             MyNodeWithProperties.CONCEPT.getID(),
-            (concept, serializedNode) -> new MyNodeWithProperties(serializedNode.getID()));
-    List<Node> unserialized = jsonSerialization.unserializeToNode(serialized);
+            (concept, serializedNode, unserializedNodesByID, propertiesValue) -> new MyNodeWithProperties(serializedNode.getID()));
+    List<Node> unserialized = jsonSerialization.unserializeToNodes(serialized);
     assertEquals(Arrays.asList(node), unserialized);
   }
 
@@ -414,8 +414,8 @@ public class SerializationOfPrimitiveValuesTest extends SerializationTest {
         .getNodeInstantiator()
         .registerCustomUnserializer(
             MyNodeWithProperties.CONCEPT.getID(),
-            (concept, serializedNode) -> new MyNodeWithProperties(serializedNode.getID()));
-    List<Node> unserialized = jsonSerialization.unserializeToNode(serialized);
+            (concept, serializedNode, unserializedNodesByID, propertiesValue) -> new MyNodeWithProperties(serializedNode.getID()));
+    List<Node> unserialized = jsonSerialization.unserializeToNodes(serialized);
     assertEquals(Arrays.asList(node), unserialized);
   }
 
@@ -554,8 +554,8 @@ public class SerializationOfPrimitiveValuesTest extends SerializationTest {
         .getNodeInstantiator()
         .registerCustomUnserializer(
             MyNodeWithProperties.CONCEPT.getID(),
-            (concept, serializedNode) -> new MyNodeWithProperties(serializedNode.getID()));
-    List<Node> unserialized = jsonSerialization.unserializeToNode(serialized);
+            (concept, serializedNode, unserializedNodesByID, propertiesValue) -> new MyNodeWithProperties(serializedNode.getID()));
+    List<Node> unserialized = jsonSerialization.unserializeToNodes(serialized);
     assertEquals(Arrays.asList(node), unserialized);
   }
 }

--- a/core/src/test/java/org/lionweb/lioncore/java/serialization/SimpleNode.java
+++ b/core/src/test/java/org/lionweb/lioncore/java/serialization/SimpleNode.java
@@ -1,4 +1,4 @@
-package org.lionweb.lioncore.java.serialization.simplemath;
+package org.lionweb.lioncore.java.serialization;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -11,7 +11,7 @@ import org.lionweb.lioncore.java.model.Model;
 import org.lionweb.lioncore.java.model.Node;
 import org.lionweb.lioncore.java.model.ReferenceValue;
 
-public abstract class SimpleMathNode implements Node {
+public abstract class SimpleNode implements Node {
 
   private String id;
   private Node parent;
@@ -129,13 +129,28 @@ public abstract class SimpleMathNode implements Node {
   @Nonnull
   @Override
   public List<ReferenceValue> getReferenceValues(@Nonnull Reference reference) {
-    throw new UnsupportedOperationException();
+    if (!getConcept().allReferences().contains(reference)) {
+      throw new IllegalArgumentException("Reference not belonging to this concept");
+    }
+    return concreteGetReferenceValues(reference);
+  }
+
+  protected List<ReferenceValue> concreteGetReferenceValues(Reference reference) {
+    throw new UnsupportedOperationException("Reference " + reference + " not yet supported");
   }
 
   @Override
   public void addReferenceValue(
       @Nonnull Reference reference, @Nullable ReferenceValue referredNode) {
-    throw new UnsupportedOperationException();
+    if (!getConcept().allReferences().contains(reference)) {
+      throw new IllegalArgumentException("Reference not belonging to this concept");
+    }
+    concreteAddReferenceValue(reference, referredNode);
+  }
+
+  public void concreteAddReferenceValue(
+      @Nonnull Reference reference, @Nullable ReferenceValue referredNode) {
+    throw new UnsupportedOperationException("Reference " + reference + " not yet supported");
   }
 
   @Override

--- a/core/src/test/java/org/lionweb/lioncore/java/serialization/refsmm/ContainerNode.java
+++ b/core/src/test/java/org/lionweb/lioncore/java/serialization/refsmm/ContainerNode.java
@@ -1,0 +1,67 @@
+package org.lionweb.lioncore.java.serialization.refsmm;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import org.lionweb.lioncore.java.metamodel.Concept;
+import org.lionweb.lioncore.java.metamodel.Containment;
+import org.lionweb.lioncore.java.model.Node;
+import org.lionweb.lioncore.java.serialization.SimpleNode;
+
+public class ContainerNode extends SimpleNode {
+  private ContainerNode contained;
+
+  public ContainerNode() {
+    this.contained = null;
+    assignRandomID();
+  }
+
+  public ContainerNode(ContainerNode contained) {
+    this.contained = contained;
+    assignRandomID();
+  }
+
+  public ContainerNode(ContainerNode contained, String id) {
+    this.contained = contained;
+    setId(id);
+  }
+
+  @Override
+  public Concept getConcept() {
+    return RefsMetamodel.CONTAINER_NODE;
+  }
+
+  @Override
+  protected List<? extends Node> concreteGetChildren(Containment containment) {
+    if (containment.getName().equals("contained")) {
+      return Arrays.asList(contained);
+    }
+    return super.concreteGetChildren(containment);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof ContainerNode)) return false;
+    ContainerNode that = (ContainerNode) o;
+    return Objects.equals(contained, that.contained);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(contained);
+  }
+
+  @Override
+  public String toString() {
+    return "ContainerNode{" + "contained=" + contained.getID() + '}';
+  }
+
+  public ContainerNode getContained() {
+    return contained;
+  }
+
+  public void setContained(ContainerNode contained) {
+    this.contained = contained;
+  }
+}

--- a/core/src/test/java/org/lionweb/lioncore/java/serialization/refsmm/RefNode.java
+++ b/core/src/test/java/org/lionweb/lioncore/java/serialization/refsmm/RefNode.java
@@ -1,0 +1,71 @@
+package org.lionweb.lioncore.java.serialization.refsmm;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.lionweb.lioncore.java.metamodel.Concept;
+import org.lionweb.lioncore.java.metamodel.Reference;
+import org.lionweb.lioncore.java.model.ReferenceValue;
+import org.lionweb.lioncore.java.serialization.SimpleNode;
+
+public class RefNode extends SimpleNode {
+  private RefNode referred;
+
+  public RefNode() {
+    assignRandomID();
+  }
+
+  public void setReferred(RefNode referred) {
+    this.referred = referred;
+  }
+
+  public RefNode(String id) {
+    setId(id);
+  }
+
+  @Override
+  public Concept getConcept() {
+    return RefsMetamodel.REF_NODE;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof RefNode)) return false;
+    RefNode that = (RefNode) o;
+    return Objects.equals(referred.getID(), that.referred.getID());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(referred.getID());
+  }
+
+  @Override
+  public String toString() {
+    return "RefNode{" + "referred=" + referred.getID() + '}';
+  }
+
+  @Override
+  protected List<ReferenceValue> concreteGetReferenceValues(Reference reference) {
+    if (reference.getName().equals("referred")) {
+      if (referred == null) {
+        return Collections.emptyList();
+      }
+      return Collections.singletonList(new ReferenceValue(referred, ""));
+    }
+    return super.concreteGetReferenceValues(reference);
+  }
+
+  @Override
+  public void concreteAddReferenceValue(
+      @Nonnull Reference reference, @Nullable ReferenceValue referredNode) {
+    if (reference.getName().equals("referred")) {
+      referred = (RefNode) referredNode.getReferred();
+      return;
+    }
+    super.concreteAddReferenceValue(reference, referredNode);
+  }
+}

--- a/core/src/test/java/org/lionweb/lioncore/java/serialization/refsmm/RefsMetamodel.java
+++ b/core/src/test/java/org/lionweb/lioncore/java/serialization/refsmm/RefsMetamodel.java
@@ -1,0 +1,32 @@
+package org.lionweb.lioncore.java.serialization.refsmm;
+
+import org.lionweb.lioncore.java.metamodel.*;
+
+public class RefsMetamodel extends Metamodel {
+  public static final RefsMetamodel INSTANCE = new RefsMetamodel();
+  public static Concept CONTAINER_NODE;
+  public static Concept REF_NODE;
+
+  private RefsMetamodel() {
+    setID("Refs");
+    setKey("Refs");
+    setName("Refs");
+    setVersion("1");
+
+    // We do not pass INSTANCE as it is still null at this point
+    CONTAINER_NODE = new Concept(null, "Container", "RefsMM_Container").setKey("RefsMM_Container");
+    REF_NODE = new Concept(null, "Ref", "RefsMM_Ref").setKey("RefsMM_Ref");
+    addElement(CONTAINER_NODE);
+    addElement(REF_NODE);
+
+    CONTAINER_NODE.addFeature(
+        Containment.createOptional("contained", CONTAINER_NODE)
+            .setID("RefsMM_Container_contained")
+            .setKey("RefsMM_Container_contained"));
+
+    REF_NODE.addFeature(
+        Reference.createOptional("referred", REF_NODE)
+            .setID("RefsMM_Ref_referred")
+            .setKey("RefsMM_Ref_referred"));
+  }
+}

--- a/core/src/test/java/org/lionweb/lioncore/java/serialization/simplemath/IntLiteral.java
+++ b/core/src/test/java/org/lionweb/lioncore/java/serialization/simplemath/IntLiteral.java
@@ -1,0 +1,54 @@
+package org.lionweb.lioncore.java.serialization.simplemath;
+
+import org.lionweb.lioncore.java.metamodel.Concept;
+import org.lionweb.lioncore.java.metamodel.Property;
+import org.lionweb.lioncore.java.model.Node;
+
+import java.util.Objects;
+
+public class IntLiteral extends SimpleMathNode {
+    private int value;
+
+    public IntLiteral(int value) {
+        assignRandomID();
+        this.value = value;
+    }
+
+    public IntLiteral(int value, String id) {
+        setId(id);
+        this.value = value;
+    }
+
+    @Override
+    public Concept getConcept() {
+        return SimpleMathMetamodel.INT_LITERAL;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof IntLiteral)) return false;
+        IntLiteral that = (IntLiteral) o;
+        return Objects.equals(getID(), that.getID()) && value == that.value;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+
+    @Override
+    public String toString() {
+        return "IntLiteral{" +
+                "value=" + value +
+                '}';
+    }
+
+    @Override
+    protected Object concreteGetPropertyValue(Property property) {
+        if (property.getName().equals("value")) {
+            return value;
+        }
+        return super.concreteGetPropertyValue(property);
+    }
+}

--- a/core/src/test/java/org/lionweb/lioncore/java/serialization/simplemath/IntLiteral.java
+++ b/core/src/test/java/org/lionweb/lioncore/java/serialization/simplemath/IntLiteral.java
@@ -1,54 +1,50 @@
 package org.lionweb.lioncore.java.serialization.simplemath;
 
+import java.util.Objects;
 import org.lionweb.lioncore.java.metamodel.Concept;
 import org.lionweb.lioncore.java.metamodel.Property;
-import org.lionweb.lioncore.java.model.Node;
-
-import java.util.Objects;
 
 public class IntLiteral extends SimpleMathNode {
-    private int value;
+  private int value;
 
-    public IntLiteral(int value) {
-        assignRandomID();
-        this.value = value;
-    }
+  public IntLiteral(int value) {
+    assignRandomID();
+    this.value = value;
+  }
 
-    public IntLiteral(int value, String id) {
-        setId(id);
-        this.value = value;
-    }
+  public IntLiteral(int value, String id) {
+    setId(id);
+    this.value = value;
+  }
 
-    @Override
-    public Concept getConcept() {
-        return SimpleMathMetamodel.INT_LITERAL;
-    }
+  @Override
+  public Concept getConcept() {
+    return SimpleMathMetamodel.INT_LITERAL;
+  }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof IntLiteral)) return false;
-        IntLiteral that = (IntLiteral) o;
-        return Objects.equals(getID(), that.getID()) && value == that.value;
-    }
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof IntLiteral)) return false;
+    IntLiteral that = (IntLiteral) o;
+    return Objects.equals(getID(), that.getID()) && value == that.value;
+  }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(value);
-    }
+  @Override
+  public int hashCode() {
+    return Objects.hash(value);
+  }
 
-    @Override
-    public String toString() {
-        return "IntLiteral{" +
-                "value=" + value +
-                '}';
-    }
+  @Override
+  public String toString() {
+    return "IntLiteral{" + "value=" + value + '}';
+  }
 
-    @Override
-    protected Object concreteGetPropertyValue(Property property) {
-        if (property.getName().equals("value")) {
-            return value;
-        }
-        return super.concreteGetPropertyValue(property);
+  @Override
+  protected Object concreteGetPropertyValue(Property property) {
+    if (property.getName().equals("value")) {
+      return value;
     }
+    return super.concreteGetPropertyValue(property);
+  }
 }

--- a/core/src/test/java/org/lionweb/lioncore/java/serialization/simplemath/IntLiteral.java
+++ b/core/src/test/java/org/lionweb/lioncore/java/serialization/simplemath/IntLiteral.java
@@ -3,8 +3,9 @@ package org.lionweb.lioncore.java.serialization.simplemath;
 import java.util.Objects;
 import org.lionweb.lioncore.java.metamodel.Concept;
 import org.lionweb.lioncore.java.metamodel.Property;
+import org.lionweb.lioncore.java.serialization.SimpleNode;
 
-public class IntLiteral extends SimpleMathNode {
+public class IntLiteral extends SimpleNode {
   private int value;
 
   public IntLiteral(int value) {

--- a/core/src/test/java/org/lionweb/lioncore/java/serialization/simplemath/SimpleMathMetamodel.java
+++ b/core/src/test/java/org/lionweb/lioncore/java/serialization/simplemath/SimpleMathMetamodel.java
@@ -3,27 +3,35 @@ package org.lionweb.lioncore.java.serialization.simplemath;
 import org.lionweb.lioncore.java.metamodel.*;
 
 public class SimpleMathMetamodel extends Metamodel {
-    public static final SimpleMathMetamodel INSTANCE = new SimpleMathMetamodel();
-    public static Concept INT_LITERAL;
-    public static Concept SUM;
+  public static final SimpleMathMetamodel INSTANCE = new SimpleMathMetamodel();
+  public static Concept INT_LITERAL;
+  public static Concept SUM;
 
-    private SimpleMathMetamodel() {
-        setID("SimpleMath");
-        setKey("SimpleMath");
-        setName("SimpleMath");
-        setVersion("1");
+  private SimpleMathMetamodel() {
+    setID("SimpleMath");
+    setKey("SimpleMath");
+    setName("SimpleMath");
+    setVersion("1");
 
-        // We do not pass INSTANCE as it is still null at this point
-        INT_LITERAL = new Concept(null, "IntLiteral", "SimpleMath_IntLiteral").setKey("SimpleMath_IntLiteral");
-        SUM = new Concept(null, "Sum", "SimpleMath_Sum").setKey("SimpleMath_Sum");
-        addElement(INT_LITERAL);
-        addElement(SUM);
+    // We do not pass INSTANCE as it is still null at this point
+    INT_LITERAL =
+        new Concept(null, "IntLiteral", "SimpleMath_IntLiteral").setKey("SimpleMath_IntLiteral");
+    SUM = new Concept(null, "Sum", "SimpleMath_Sum").setKey("SimpleMath_Sum");
+    addElement(INT_LITERAL);
+    addElement(SUM);
 
-        SUM.addFeature(Containment.createRequired("left", INT_LITERAL).setID("SimpleMath_Sum_left").setKey("SimpleMath_Sum_left"));
-        SUM.addFeature(Containment.createRequired("right", INT_LITERAL).setID("SimpleMath_Sum_right").setKey("SimpleMath_Sum_right"));
+    SUM.addFeature(
+        Containment.createRequired("left", INT_LITERAL)
+            .setID("SimpleMath_Sum_left")
+            .setKey("SimpleMath_Sum_left"));
+    SUM.addFeature(
+        Containment.createRequired("right", INT_LITERAL)
+            .setID("SimpleMath_Sum_right")
+            .setKey("SimpleMath_Sum_right"));
 
-        INT_LITERAL.addFeature(Property.createRequired("value", LionCoreBuiltins.getInteger())
-                .setID("SimpleMath_IntLiteral_value")
-                .setKey("SimpleMath_IntLiteral_value"));
-    }
+    INT_LITERAL.addFeature(
+        Property.createRequired("value", LionCoreBuiltins.getInteger())
+            .setID("SimpleMath_IntLiteral_value")
+            .setKey("SimpleMath_IntLiteral_value"));
+  }
 }

--- a/core/src/test/java/org/lionweb/lioncore/java/serialization/simplemath/SimpleMathMetamodel.java
+++ b/core/src/test/java/org/lionweb/lioncore/java/serialization/simplemath/SimpleMathMetamodel.java
@@ -1,0 +1,29 @@
+package org.lionweb.lioncore.java.serialization.simplemath;
+
+import org.lionweb.lioncore.java.metamodel.*;
+
+public class SimpleMathMetamodel extends Metamodel {
+    public static final SimpleMathMetamodel INSTANCE = new SimpleMathMetamodel();
+    public static Concept INT_LITERAL;
+    public static Concept SUM;
+
+    private SimpleMathMetamodel() {
+        setID("SimpleMath");
+        setKey("SimpleMath");
+        setName("SimpleMath");
+        setVersion("1");
+
+        // We do not pass INSTANCE as it is still null at this point
+        INT_LITERAL = new Concept(null, "IntLiteral", "SimpleMath_IntLiteral").setKey("SimpleMath_IntLiteral");
+        SUM = new Concept(null, "Sum", "SimpleMath_Sum").setKey("SimpleMath_Sum");
+        addElement(INT_LITERAL);
+        addElement(SUM);
+
+        SUM.addFeature(Containment.createRequired("left", INT_LITERAL).setID("SimpleMath_Sum_left").setKey("SimpleMath_Sum_left"));
+        SUM.addFeature(Containment.createRequired("right", INT_LITERAL).setID("SimpleMath_Sum_right").setKey("SimpleMath_Sum_right"));
+
+        INT_LITERAL.addFeature(Property.createRequired("value", LionCoreBuiltins.getInteger())
+                .setID("SimpleMath_IntLiteral_value")
+                .setKey("SimpleMath_IntLiteral_value"));
+    }
+}

--- a/core/src/test/java/org/lionweb/lioncore/java/serialization/simplemath/SimpleMathNode.java
+++ b/core/src/test/java/org/lionweb/lioncore/java/serialization/simplemath/SimpleMathNode.java
@@ -1,0 +1,155 @@
+package org.lionweb.lioncore.java.serialization.simplemath;
+
+import org.lionweb.lioncore.java.metamodel.*;
+import org.lionweb.lioncore.java.model.AnnotationInstance;
+import org.lionweb.lioncore.java.model.Model;
+import org.lionweb.lioncore.java.model.Node;
+import org.lionweb.lioncore.java.model.ReferenceValue;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Random;
+
+public abstract class SimpleMathNode implements Node {
+
+    private String id;
+    private Node parent;
+
+    protected void assignRandomID() {
+        String randomId = "id_" + Math.abs(new Random().nextLong());
+        setId(randomId);
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public void setParent(Node parent) {
+        this.parent = parent;
+    }
+
+    @Nullable
+    @Override
+    public String getID() {
+        return id;
+    }
+
+    @Override
+    public Model getModel() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Node getParent() {
+        return parent;
+    }
+
+    @Override
+    public List<AnnotationInstance> getAnnotations() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Containment getContainmentFeature() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Nonnull
+    @Override
+    public List<AnnotationInstance> getAnnotations(Annotation annotation) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addAnnotation(AnnotationInstance instance) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object getPropertyValueByName(String propertyName) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setPropertyValueByName(String propertyName, Object value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object getPropertyValueByID(String propertyID) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object getPropertyValue(Property property) {
+        if (!getConcept().allProperties().contains(property)) {
+            throw new IllegalArgumentException("Property not belonging to this concept");
+        }
+        return concreteGetPropertyValue(property);
+    }
+
+    protected Object concreteGetPropertyValue(Property property) {
+        throw new UnsupportedOperationException("Property " + property + " not yet supported");
+    }
+
+    @Override
+    public void setPropertyValue(Property property, Object value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<? extends Node> getChildren(Containment containment) {
+        if (!getConcept().allContainments().contains(containment)) {
+            throw new IllegalArgumentException("Containment not belonging to this concept");
+        }
+        return concreteGetChildren(containment);
+    }
+
+    protected List<? extends Node> concreteGetChildren(Containment containment) {
+        throw new UnsupportedOperationException("Containment " + containment + " not yet supported");
+    }
+
+    @Override
+    public void addChild(Containment containment, Node child) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removeChild(Node node) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Nonnull
+    @Override
+    public List<Node> getReferredNodes(@Nonnull Reference reference) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Nonnull
+    @Override
+    public List<ReferenceValue> getReferenceValues(@Nonnull Reference reference) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addReferenceValue(@Nonnull Reference reference, @Nullable ReferenceValue referredNode) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Node getRoot() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<Node> getChildren() {
+        List<Node> allChildren = new LinkedList<>();
+        getConcept().allContainments().stream()
+                .map(c -> getChildren(c))
+                .forEach(children -> allChildren.addAll(children));
+        return allChildren;
+    }
+}

--- a/core/src/test/java/org/lionweb/lioncore/java/serialization/simplemath/SimpleMathNode.java
+++ b/core/src/test/java/org/lionweb/lioncore/java/serialization/simplemath/SimpleMathNode.java
@@ -1,155 +1,154 @@
 package org.lionweb.lioncore.java.serialization.simplemath;
 
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Random;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.lionweb.lioncore.java.metamodel.*;
 import org.lionweb.lioncore.java.model.AnnotationInstance;
 import org.lionweb.lioncore.java.model.Model;
 import org.lionweb.lioncore.java.model.Node;
 import org.lionweb.lioncore.java.model.ReferenceValue;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.util.Arrays;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Random;
-
 public abstract class SimpleMathNode implements Node {
 
-    private String id;
-    private Node parent;
+  private String id;
+  private Node parent;
 
-    protected void assignRandomID() {
-        String randomId = "id_" + Math.abs(new Random().nextLong());
-        setId(randomId);
-    }
+  protected void assignRandomID() {
+    String randomId = "id_" + Math.abs(new Random().nextLong());
+    setId(randomId);
+  }
 
-    public void setId(String id) {
-        this.id = id;
-    }
+  public void setId(String id) {
+    this.id = id;
+  }
 
-    public void setParent(Node parent) {
-        this.parent = parent;
-    }
+  public void setParent(Node parent) {
+    this.parent = parent;
+  }
 
-    @Nullable
-    @Override
-    public String getID() {
-        return id;
-    }
+  @Nullable
+  @Override
+  public String getID() {
+    return id;
+  }
 
-    @Override
-    public Model getModel() {
-        throw new UnsupportedOperationException();
-    }
+  @Override
+  public Model getModel() {
+    throw new UnsupportedOperationException();
+  }
 
-    @Override
-    public Node getParent() {
-        return parent;
-    }
+  @Override
+  public Node getParent() {
+    return parent;
+  }
 
-    @Override
-    public List<AnnotationInstance> getAnnotations() {
-        throw new UnsupportedOperationException();
-    }
+  @Override
+  public List<AnnotationInstance> getAnnotations() {
+    throw new UnsupportedOperationException();
+  }
 
-    @Override
-    public Containment getContainmentFeature() {
-        throw new UnsupportedOperationException();
-    }
+  @Override
+  public Containment getContainmentFeature() {
+    throw new UnsupportedOperationException();
+  }
 
-    @Nonnull
-    @Override
-    public List<AnnotationInstance> getAnnotations(Annotation annotation) {
-        throw new UnsupportedOperationException();
-    }
+  @Nonnull
+  @Override
+  public List<AnnotationInstance> getAnnotations(Annotation annotation) {
+    throw new UnsupportedOperationException();
+  }
 
-    @Override
-    public void addAnnotation(AnnotationInstance instance) {
-        throw new UnsupportedOperationException();
-    }
+  @Override
+  public void addAnnotation(AnnotationInstance instance) {
+    throw new UnsupportedOperationException();
+  }
 
-    @Override
-    public Object getPropertyValueByName(String propertyName) {
-        throw new UnsupportedOperationException();
-    }
+  @Override
+  public Object getPropertyValueByName(String propertyName) {
+    throw new UnsupportedOperationException();
+  }
 
-    @Override
-    public void setPropertyValueByName(String propertyName, Object value) {
-        throw new UnsupportedOperationException();
-    }
+  @Override
+  public void setPropertyValueByName(String propertyName, Object value) {
+    throw new UnsupportedOperationException();
+  }
 
-    @Override
-    public Object getPropertyValueByID(String propertyID) {
-        throw new UnsupportedOperationException();
-    }
+  @Override
+  public Object getPropertyValueByID(String propertyID) {
+    throw new UnsupportedOperationException();
+  }
 
-    @Override
-    public Object getPropertyValue(Property property) {
-        if (!getConcept().allProperties().contains(property)) {
-            throw new IllegalArgumentException("Property not belonging to this concept");
-        }
-        return concreteGetPropertyValue(property);
+  @Override
+  public Object getPropertyValue(Property property) {
+    if (!getConcept().allProperties().contains(property)) {
+      throw new IllegalArgumentException("Property not belonging to this concept");
     }
+    return concreteGetPropertyValue(property);
+  }
 
-    protected Object concreteGetPropertyValue(Property property) {
-        throw new UnsupportedOperationException("Property " + property + " not yet supported");
-    }
+  protected Object concreteGetPropertyValue(Property property) {
+    throw new UnsupportedOperationException("Property " + property + " not yet supported");
+  }
 
-    @Override
-    public void setPropertyValue(Property property, Object value) {
-        throw new UnsupportedOperationException();
-    }
+  @Override
+  public void setPropertyValue(Property property, Object value) {
+    throw new UnsupportedOperationException();
+  }
 
-    @Override
-    public List<? extends Node> getChildren(Containment containment) {
-        if (!getConcept().allContainments().contains(containment)) {
-            throw new IllegalArgumentException("Containment not belonging to this concept");
-        }
-        return concreteGetChildren(containment);
+  @Override
+  public List<? extends Node> getChildren(Containment containment) {
+    if (!getConcept().allContainments().contains(containment)) {
+      throw new IllegalArgumentException("Containment not belonging to this concept");
     }
+    return concreteGetChildren(containment);
+  }
 
-    protected List<? extends Node> concreteGetChildren(Containment containment) {
-        throw new UnsupportedOperationException("Containment " + containment + " not yet supported");
-    }
+  protected List<? extends Node> concreteGetChildren(Containment containment) {
+    throw new UnsupportedOperationException("Containment " + containment + " not yet supported");
+  }
 
-    @Override
-    public void addChild(Containment containment, Node child) {
-        throw new UnsupportedOperationException();
-    }
+  @Override
+  public void addChild(Containment containment, Node child) {
+    throw new UnsupportedOperationException();
+  }
 
-    @Override
-    public void removeChild(Node node) {
-        throw new UnsupportedOperationException();
-    }
+  @Override
+  public void removeChild(Node node) {
+    throw new UnsupportedOperationException();
+  }
 
-    @Nonnull
-    @Override
-    public List<Node> getReferredNodes(@Nonnull Reference reference) {
-        throw new UnsupportedOperationException();
-    }
+  @Nonnull
+  @Override
+  public List<Node> getReferredNodes(@Nonnull Reference reference) {
+    throw new UnsupportedOperationException();
+  }
 
-    @Nonnull
-    @Override
-    public List<ReferenceValue> getReferenceValues(@Nonnull Reference reference) {
-        throw new UnsupportedOperationException();
-    }
+  @Nonnull
+  @Override
+  public List<ReferenceValue> getReferenceValues(@Nonnull Reference reference) {
+    throw new UnsupportedOperationException();
+  }
 
-    @Override
-    public void addReferenceValue(@Nonnull Reference reference, @Nullable ReferenceValue referredNode) {
-        throw new UnsupportedOperationException();
-    }
+  @Override
+  public void addReferenceValue(
+      @Nonnull Reference reference, @Nullable ReferenceValue referredNode) {
+    throw new UnsupportedOperationException();
+  }
 
-    @Override
-    public Node getRoot() {
-        throw new UnsupportedOperationException();
-    }
+  @Override
+  public Node getRoot() {
+    throw new UnsupportedOperationException();
+  }
 
-    @Override
-    public List<Node> getChildren() {
-        List<Node> allChildren = new LinkedList<>();
-        getConcept().allContainments().stream()
-                .map(c -> getChildren(c))
-                .forEach(children -> allChildren.addAll(children));
-        return allChildren;
-    }
+  @Override
+  public List<Node> getChildren() {
+    List<Node> allChildren = new LinkedList<>();
+    getConcept().allContainments().stream()
+        .map(c -> getChildren(c))
+        .forEach(children -> allChildren.addAll(children));
+    return allChildren;
+  }
 }

--- a/core/src/test/java/org/lionweb/lioncore/java/serialization/simplemath/Sum.java
+++ b/core/src/test/java/org/lionweb/lioncore/java/serialization/simplemath/Sum.java
@@ -6,8 +6,9 @@ import java.util.Objects;
 import org.lionweb.lioncore.java.metamodel.Concept;
 import org.lionweb.lioncore.java.metamodel.Containment;
 import org.lionweb.lioncore.java.model.Node;
+import org.lionweb.lioncore.java.serialization.SimpleNode;
 
-public class Sum extends SimpleMathNode {
+public class Sum extends SimpleNode {
   private IntLiteral left;
   private IntLiteral right;
 

--- a/core/src/test/java/org/lionweb/lioncore/java/serialization/simplemath/Sum.java
+++ b/core/src/test/java/org/lionweb/lioncore/java/serialization/simplemath/Sum.java
@@ -1,63 +1,61 @@
 package org.lionweb.lioncore.java.serialization.simplemath;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
 import org.lionweb.lioncore.java.metamodel.Concept;
 import org.lionweb.lioncore.java.metamodel.Containment;
 import org.lionweb.lioncore.java.model.Node;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
-
 public class Sum extends SimpleMathNode {
-    private IntLiteral left;
-    private IntLiteral right;
+  private IntLiteral left;
+  private IntLiteral right;
 
-    public Sum(IntLiteral left, IntLiteral right) {
-        this.left = left;
-        this.right = right;
-        assignRandomID();
-    }
+  public Sum(IntLiteral left, IntLiteral right) {
+    this.left = left;
+    this.right = right;
+    assignRandomID();
+  }
 
-    public Sum(IntLiteral left, IntLiteral right, String id) {
-        this.left = left;
-        this.right = right;
-        setId(id);
-    }
+  public Sum(IntLiteral left, IntLiteral right, String id) {
+    this.left = left;
+    this.right = right;
+    setId(id);
+  }
 
-    @Override
-    public Concept getConcept() {
-        return SimpleMathMetamodel.SUM;
-    }
+  @Override
+  public Concept getConcept() {
+    return SimpleMathMetamodel.SUM;
+  }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof Sum)) return false;
-        Sum sum = (Sum) o;
-        return Objects.equals(getID(), sum.getID()) && Objects.equals(left, sum.left) && Objects.equals(right, sum.right);
-    }
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof Sum)) return false;
+    Sum sum = (Sum) o;
+    return Objects.equals(getID(), sum.getID())
+        && Objects.equals(left, sum.left)
+        && Objects.equals(right, sum.right);
+  }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(left, right);
-    }
+  @Override
+  public int hashCode() {
+    return Objects.hash(left, right);
+  }
 
-    @Override
-    public String toString() {
-        return "Sum{" +
-                "left=" + left +
-                ", right=" + right +
-                '}';
-    }
+  @Override
+  public String toString() {
+    return "Sum{" + "left=" + left + ", right=" + right + '}';
+  }
 
-    @Override
-    protected List<? extends Node> concreteGetChildren(Containment containment) {
-        if (containment.getName().equals("left")) {
-            return Arrays.asList(left);
-        }
-        if (containment.getName().equals("right")) {
-            return Arrays.asList(right);
-        }
-        return super.concreteGetChildren(containment);
+  @Override
+  protected List<? extends Node> concreteGetChildren(Containment containment) {
+    if (containment.getName().equals("left")) {
+      return Arrays.asList(left);
     }
+    if (containment.getName().equals("right")) {
+      return Arrays.asList(right);
+    }
+    return super.concreteGetChildren(containment);
+  }
 }

--- a/core/src/test/java/org/lionweb/lioncore/java/serialization/simplemath/Sum.java
+++ b/core/src/test/java/org/lionweb/lioncore/java/serialization/simplemath/Sum.java
@@ -1,0 +1,67 @@
+package org.lionweb.lioncore.java.serialization.simplemath;
+
+import org.lionweb.lioncore.java.metamodel.*;
+import org.lionweb.lioncore.java.model.AnnotationInstance;
+import org.lionweb.lioncore.java.model.Model;
+import org.lionweb.lioncore.java.model.Node;
+import org.lionweb.lioncore.java.model.ReferenceValue;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+public class Sum extends SimpleMathNode {
+    private IntLiteral left;
+    private IntLiteral right;
+
+    public Sum(IntLiteral left, IntLiteral right) {
+        this.left = left;
+        this.right = right;
+        assignRandomID();
+    }
+
+    public Sum(IntLiteral left, IntLiteral right, String id) {
+        this.left = left;
+        this.right = right;
+        setId(id);
+    }
+
+    @Override
+    public Concept getConcept() {
+        return SimpleMathMetamodel.SUM;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Sum)) return false;
+        Sum sum = (Sum) o;
+        return Objects.equals(getID(), sum.getID()) && Objects.equals(left, sum.left) && Objects.equals(right, sum.right);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(left, right);
+    }
+
+    @Override
+    public String toString() {
+        return "Sum{" +
+                "left=" + left +
+                ", right=" + right +
+                '}';
+    }
+
+    @Override
+    protected List<? extends Node> concreteGetChildren(Containment containment) {
+        if (containment.getName().equals("left")) {
+            return Arrays.asList(left);
+        }
+        if (containment.getName().equals("right")) {
+            return Arrays.asList(right);
+        }
+        return super.concreteGetChildren(containment);
+    }
+}

--- a/core/src/test/java/org/lionweb/lioncore/java/serialization/simplemath/Sum.java
+++ b/core/src/test/java/org/lionweb/lioncore/java/serialization/simplemath/Sum.java
@@ -1,13 +1,9 @@
 package org.lionweb.lioncore.java.serialization.simplemath;
 
-import org.lionweb.lioncore.java.metamodel.*;
-import org.lionweb.lioncore.java.model.AnnotationInstance;
-import org.lionweb.lioncore.java.model.Model;
+import org.lionweb.lioncore.java.metamodel.Concept;
+import org.lionweb.lioncore.java.metamodel.Containment;
 import org.lionweb.lioncore.java.model.Node;
-import org.lionweb.lioncore.java.model.ReferenceValue;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;


### PR DESCRIPTION
The changes permits to unserialize nodes directly by using the values of properties and children and construction time.
To do so we want to start instantiating the nodes starting from the leaves and we want to provide the values of properties and children to the custom unserializers