### PR TITLE
Validating LionCore and LionCoreBuiltins metamodels

### DIFF
--- a/core/src/main/java/org/lionweb/lioncore/java/metamodel/LionCoreBuiltins.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/metamodel/LionCoreBuiltins.java
@@ -1,8 +1,5 @@
 package org.lionweb.lioncore.java.metamodel;
 
-import org.lionweb.lioncore.java.utils.MetamodelValidator;
-import org.lionweb.lioncore.java.utils.ValidationResult;
-
 public class LionCoreBuiltins extends Metamodel {
   private static LionCoreBuiltins INSTANCE = new LionCoreBuiltins();
 
@@ -11,20 +8,16 @@ public class LionCoreBuiltins extends Metamodel {
     super("org.lionweb.Builtins");
     setID("lioncore_builtins");
     setKey("lioncore_builtins");
-    this.addElement(new PrimitiveType(this, "String"));
-    this.addElement(new PrimitiveType(this, "Boolean"));
-    this.addElement(new PrimitiveType(this, "Integer"));
-    this.addElement(new PrimitiveType(this, "JSON"));
+    new PrimitiveType(this, "String");
+    new PrimitiveType(this, "Boolean");
+    new PrimitiveType(this, "Integer");
+    new PrimitiveType(this, "JSON");
     this.getElements()
         .forEach(
             e -> {
               e.setID("LIonCore_M3_" + e.getName());
               e.setKey(e.getName());
             });
-    ValidationResult vr = new MetamodelValidator().validate(this);
-    if (!vr.isSuccessful()) {
-      throw new RuntimeException("LionCoreBuiltins Metamodel is not valid: " + vr);
-    }
   }
 
   public static LionCoreBuiltins getInstance() {

--- a/core/src/main/java/org/lionweb/lioncore/java/metamodel/LionCoreBuiltins.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/metamodel/LionCoreBuiltins.java
@@ -1,5 +1,8 @@
 package org.lionweb.lioncore.java.metamodel;
 
+import org.lionweb.lioncore.java.utils.MetamodelValidator;
+import org.lionweb.lioncore.java.utils.ValidationResult;
+
 public class LionCoreBuiltins extends Metamodel {
   private static LionCoreBuiltins INSTANCE = new LionCoreBuiltins();
 
@@ -18,6 +21,10 @@ public class LionCoreBuiltins extends Metamodel {
               e.setID("LIonCore_M3_" + e.getName());
               e.setKey(e.getName());
             });
+    ValidationResult vr = new MetamodelValidator().validate(this);
+    if (!vr.isSuccessful()) {
+      throw new RuntimeException("LionCoreBuiltins Metamodel is not valid: " + vr);
+    }
   }
 
   public static LionCoreBuiltins getInstance() {

--- a/core/src/main/java/org/lionweb/lioncore/java/metamodel/MetamodelElement.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/metamodel/MetamodelElement.java
@@ -28,8 +28,12 @@ public abstract class MetamodelElement<T extends M3Node> extends M3Node<T>
 
   public MetamodelElement(@Nullable Metamodel metamodel, @Nullable String name) {
     // TODO enforce uniqueness of the name within the Metamodel
-    this.setParent(metamodel);
     this.setName(name);
+    if (metamodel != null) {
+      metamodel.addElement(this);
+    } else {
+      this.setParent(null);
+    }
   }
 
   /**

--- a/core/src/main/java/org/lionweb/lioncore/java/model/impl/M3Node.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/model/impl/M3Node.java
@@ -293,9 +293,17 @@ public abstract class M3Node<T extends M3Node> implements Node {
     }
   }
 
-  protected void addContainmentMultipleValue(@Nonnull String linkName, Node value) {
+  /**
+   * Adding a null value or a value already contained, do not produce any change.
+   *
+   * @return return true if the addition produced a change
+   */
+  protected boolean addContainmentMultipleValue(@Nonnull String linkName, Node value) {
     if (value == null) {
-      return;
+      return false;
+    }
+    if (getContainmentMultipleValue(linkName).contains(value)) {
+      return false;
     }
     ((M3Node) value).setParent(this);
     if (containmentValues.containsKey(linkName)) {
@@ -303,6 +311,7 @@ public abstract class M3Node<T extends M3Node> implements Node {
     } else {
       containmentValues.put(linkName, new ArrayList(Arrays.asList(value)));
     }
+    return true;
   }
 
   protected void addReferenceMultipleValue(String linkName, ReferenceValue value) {

--- a/core/src/main/java/org/lionweb/lioncore/java/self/LionCore.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/self/LionCore.java
@@ -3,8 +3,6 @@ package org.lionweb.lioncore.java.self;
 import java.util.*;
 import org.lionweb.lioncore.java.metamodel.*;
 import org.lionweb.lioncore.java.model.impl.M3Node;
-import org.lionweb.lioncore.java.utils.MetamodelValidator;
-import org.lionweb.lioncore.java.utils.ValidationResult;
 
 public class LionCore {
 
@@ -202,10 +200,6 @@ public class LionCore {
       checkIDs(INSTANCE);
     }
     checkIDs(INSTANCE);
-    ValidationResult vr = new MetamodelValidator().validate(INSTANCE);
-    if (!vr.isSuccessful()) {
-      throw new RuntimeException("LionCore Metamodel is not valid: " + vr);
-    }
     return INSTANCE;
   }
 

--- a/core/src/main/java/org/lionweb/lioncore/java/self/LionCore.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/self/LionCore.java
@@ -3,6 +3,8 @@ package org.lionweb.lioncore.java.self;
 import java.util.*;
 import org.lionweb.lioncore.java.metamodel.*;
 import org.lionweb.lioncore.java.model.impl.M3Node;
+import org.lionweb.lioncore.java.utils.MetamodelValidator;
+import org.lionweb.lioncore.java.utils.ValidationResult;
 
 public class LionCore {
 
@@ -200,6 +202,10 @@ public class LionCore {
       checkIDs(INSTANCE);
     }
     checkIDs(INSTANCE);
+    ValidationResult vr = new MetamodelValidator().validate(INSTANCE);
+    if (!vr.isSuccessful()) {
+      throw new RuntimeException("LionCore Metamodel is not valid: " + vr);
+    }
     return INSTANCE;
   }
 

--- a/core/src/main/java/org/lionweb/lioncore/java/utils/MetamodelValidator.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/utils/MetamodelValidator.java
@@ -108,7 +108,9 @@ public class MetamodelValidator extends Validator<Metamodel> {
               if (entry.getValue().size() > 1) {
                 entry
                     .getValue()
-                    .forEach((NamespacedEntity el) -> result.addError("Duplicate name", el));
+                    .forEach(
+                        (NamespacedEntity el) ->
+                            result.addError("Duplicate name " + el.getName(), el));
               }
             });
   }

--- a/core/src/main/java/org/lionweb/lioncore/java/utils/ValidationResult.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/utils/ValidationResult.java
@@ -2,6 +2,7 @@ package org.lionweb.lioncore.java.utils;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class ValidationResult {
   private final Set<Issue> issues = new HashSet<>();
@@ -24,5 +25,12 @@ public class ValidationResult {
       issues.add(new Issue(IssueSeverity.Error, message, subject));
     }
     return this;
+  }
+
+  @Override
+  public String toString() {
+    return "ValidationResult("
+        + issues.stream().map(Issue::toString).collect(Collectors.joining(", "))
+        + ")";
   }
 }

--- a/core/src/test/java/org/lionweb/lioncore/java/metamodel/LionCoreBuiltinsTest.java
+++ b/core/src/test/java/org/lionweb/lioncore/java/metamodel/LionCoreBuiltinsTest.java
@@ -3,6 +3,8 @@ package org.lionweb.lioncore.java.metamodel;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
+import org.lionweb.lioncore.java.utils.MetamodelValidator;
+import org.lionweb.lioncore.java.utils.ValidationResult;
 
 public class LionCoreBuiltinsTest {
 
@@ -20,5 +22,13 @@ public class LionCoreBuiltinsTest {
     assertEquals("LIonCore_M3_Boolean", LionCoreBuiltins.getBoolean().getID());
     assertEquals("LIonCore_M3_Integer", LionCoreBuiltins.getInteger().getID());
     assertEquals("LIonCore_M3_JSON", LionCoreBuiltins.getJSON().getID());
+  }
+
+  @Test
+  public void lionCoreBuiltinsIsValid() {
+    ValidationResult vr = new MetamodelValidator().validate(LionCoreBuiltins.getInstance());
+    if (!vr.isSuccessful()) {
+      throw new RuntimeException("LionCoreBuiltins Metamodel is not valid: " + vr);
+    }
   }
 }

--- a/core/src/test/java/org/lionweb/lioncore/java/self/LionCoreTest.java
+++ b/core/src/test/java/org/lionweb/lioncore/java/self/LionCoreTest.java
@@ -1,0 +1,16 @@
+package org.lionweb.lioncore.java.self;
+
+import org.junit.Test;
+import org.lionweb.lioncore.java.utils.MetamodelValidator;
+import org.lionweb.lioncore.java.utils.ValidationResult;
+
+public class LionCoreTest {
+
+  @Test
+  public void lionCoreIsValid() {
+    ValidationResult vr = new MetamodelValidator().validate(LionCore.getInstance());
+    if (!vr.isSuccessful()) {
+      throw new RuntimeException("LionCore Metamodel is not valid: " + vr);
+    }
+  }
+}


### PR DESCRIPTION
We add test to validate the two metamodels. We also add minor refinements. The most impactful is in the costructor of MetamodelElement: when specifying a metamodel as a parent the created element is added to that metamodel