### PR TITLE
Verify references across metamodels can be unserialized

### DIFF
--- a/core/src/main/java/org/lionweb/lioncore/java/api/LocalNodeResolver.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/api/LocalNodeResolver.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import org.lionweb.lioncore.java.metamodel.Metamodel;
 import org.lionweb.lioncore.java.model.Node;
 
 /** This NodeResolver consult a given list of nodes to find the one with the requested ID. */
@@ -29,5 +31,10 @@ public class LocalNodeResolver implements NodeResolver {
 
   public void addAll(@Nonnull List<Node> nodes) {
     nodes.forEach(n -> add(n));
+  }
+
+  public void addTree(@Nonnull Node root) {
+    add(root);
+    root.getChildren().forEach(c -> addTree(c));
   }
 }

--- a/core/src/main/java/org/lionweb/lioncore/java/api/LocalNodeResolver.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/api/LocalNodeResolver.java
@@ -5,8 +5,6 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
-import org.lionweb.lioncore.java.metamodel.Metamodel;
 import org.lionweb.lioncore.java.model.Node;
 
 /** This NodeResolver consult a given list of nodes to find the one with the requested ID. */

--- a/core/src/main/java/org/lionweb/lioncore/java/metamodel/Concept.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/metamodel/Concept.java
@@ -200,7 +200,6 @@ public class Concept extends FeaturesContainer<Concept> {
   }
 
   public @Nullable Reference getReferenceByMetaPointer(MetaPointer metaPointer) {
-    // getMetamodel().dependsOn()
     return this.allReferences().stream()
         .filter(p -> MetaPointer.from(p, this.getMetamodel()).equals(metaPointer))
         .findFirst()

--- a/core/src/main/java/org/lionweb/lioncore/java/metamodel/Concept.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/metamodel/Concept.java
@@ -200,10 +200,9 @@ public class Concept extends FeaturesContainer<Concept> {
   }
 
   public @Nullable Reference getReferenceByMetaPointer(MetaPointer metaPointer) {
-    //getMetamodel().dependsOn()
+    // getMetamodel().dependsOn()
     return this.allReferences().stream()
-        .filter(p ->
-                MetaPointer.from(p, this.getMetamodel()).equals(metaPointer))
+        .filter(p -> MetaPointer.from(p, this.getMetamodel()).equals(metaPointer))
         .findFirst()
         .orElse(null);
   }

--- a/core/src/main/java/org/lionweb/lioncore/java/metamodel/Concept.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/metamodel/Concept.java
@@ -200,8 +200,10 @@ public class Concept extends FeaturesContainer<Concept> {
   }
 
   public @Nullable Reference getReferenceByMetaPointer(MetaPointer metaPointer) {
+    //getMetamodel().dependsOn()
     return this.allReferences().stream()
-        .filter(p -> MetaPointer.from(p, this.getMetamodel()).equals(metaPointer))
+        .filter(p ->
+                MetaPointer.from(p, this.getMetamodel()).equals(metaPointer))
         .findFirst()
         .orElse(null);
   }

--- a/core/src/main/java/org/lionweb/lioncore/java/metamodel/LionCoreBuiltins.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/metamodel/LionCoreBuiltins.java
@@ -8,10 +8,10 @@ public class LionCoreBuiltins extends Metamodel {
     super("org.lionweb.Builtins");
     setID("lioncore_builtins");
     setKey("lioncore_builtins");
-    this.addElement(new PrimitiveType(this, "String"));
-    this.addElement(new PrimitiveType(this, "Boolean"));
-    this.addElement(new PrimitiveType(this, "Integer"));
-    this.addElement(new PrimitiveType(this, "JSON"));
+    new PrimitiveType(this, "String");
+    new PrimitiveType(this, "Boolean");
+    new PrimitiveType(this, "Integer");
+    new PrimitiveType(this, "JSON");
     this.getElements()
         .forEach(
             e -> {

--- a/core/src/main/java/org/lionweb/lioncore/java/metamodel/MetamodelElement.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/metamodel/MetamodelElement.java
@@ -28,8 +28,12 @@ public abstract class MetamodelElement<T extends M3Node> extends M3Node<T>
 
   public MetamodelElement(@Nullable Metamodel metamodel, @Nullable String name) {
     // TODO enforce uniqueness of the name within the Metamodel
-    this.setParent(metamodel);
     this.setName(name);
+    if (metamodel != null) {
+      metamodel.addElement(this);
+    } else {
+      this.setParent(null);
+    }
   }
 
   /**

--- a/core/src/main/java/org/lionweb/lioncore/java/model/impl/M3Node.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/model/impl/M3Node.java
@@ -293,9 +293,17 @@ public abstract class M3Node<T extends M3Node> implements Node {
     }
   }
 
-  protected void addContainmentMultipleValue(@Nonnull String linkName, Node value) {
+  /**
+   * Adding a null value or a value already contained, do not produce any change.
+   *
+   * @return return true if the addition produced a change
+   */
+  protected boolean addContainmentMultipleValue(@Nonnull String linkName, Node value) {
     if (value == null) {
-      return;
+      return false;
+    }
+    if (getContainmentMultipleValue(linkName).contains(value)) {
+      return false;
     }
     ((M3Node) value).setParent(this);
     if (containmentValues.containsKey(linkName)) {
@@ -303,6 +311,7 @@ public abstract class M3Node<T extends M3Node> implements Node {
     } else {
       containmentValues.put(linkName, new ArrayList(Arrays.asList(value)));
     }
+    return true;
   }
 
   protected void addReferenceMultipleValue(String linkName, ReferenceValue value) {

--- a/core/src/main/java/org/lionweb/lioncore/java/serialization/JsonSerialization.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/serialization/JsonSerialization.java
@@ -3,6 +3,9 @@ package org.lionweb.lioncore.java.serialization;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.*;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -258,6 +261,10 @@ public class JsonSerialization {
 
   public List<Node> unserializeToNode(String json) {
     return unserializeToNode(JsonParser.parseString(json));
+  }
+
+  public List<Node> unserializeToNodes(InputStream inputStream) {
+      return unserializeToNode(JsonParser.parseReader(new InputStreamReader(inputStream)));
   }
 
   //

--- a/core/src/main/java/org/lionweb/lioncore/java/serialization/JsonSerialization.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/serialization/JsonSerialization.java
@@ -3,7 +3,6 @@ package org.lionweb.lioncore.java.serialization;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
-
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.*;
@@ -264,7 +263,7 @@ public class JsonSerialization {
   }
 
   public List<Node> unserializeToNodes(InputStream inputStream) {
-      return unserializeToNode(JsonParser.parseReader(new InputStreamReader(inputStream)));
+    return unserializeToNode(JsonParser.parseReader(new InputStreamReader(inputStream)));
   }
 
   //
@@ -290,7 +289,7 @@ public class JsonSerialization {
             .map(n -> instantiateNodeFromSerialized(n))
             .collect(Collectors.toList());
     if (nodes.stream().map(n -> n.getID()).distinct().count() != nodes.size()) {
-        throw new IllegalStateException("Duplicate IDs found");
+      throw new IllegalStateException("Duplicate IDs found");
     }
     NodeResolver nodeResolver =
         new CompositeNodeResolver(new LocalNodeResolver(nodes), this.nodeResolver);

--- a/core/src/main/java/org/lionweb/lioncore/java/serialization/JsonSerialization.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/serialization/JsonSerialization.java
@@ -289,6 +289,9 @@ public class JsonSerialization {
         serializationBlock.getNodes().stream()
             .map(n -> instantiateNodeFromSerialized(n))
             .collect(Collectors.toList());
+    if (nodes.stream().map(n -> n.getID()).distinct().count() != nodes.size()) {
+        throw new IllegalStateException("Duplicate IDs found");
+    }
     NodeResolver nodeResolver =
         new CompositeNodeResolver(new LocalNodeResolver(nodes), this.nodeResolver);
     serializationBlock.getNodes().stream().forEach(n -> populateNode(n, nodeResolver));

--- a/core/src/main/java/org/lionweb/lioncore/java/serialization/JsonSerialization.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/serialization/JsonSerialization.java
@@ -288,8 +288,15 @@ public class JsonSerialization {
         serializationBlock.getNodes().stream()
             .map(n -> instantiateNodeFromSerialized(n))
             .collect(Collectors.toList());
-    if (nodes.stream().map(n -> n.getID()).distinct().count() != nodes.size()) {
-      throw new IllegalStateException("Duplicate IDs found");
+    Map<String, List<Node>> nodesByID =
+        nodes.stream().collect(Collectors.groupingBy(n -> n.getID()));
+    List<String> duplicateIDs =
+        nodesByID.entrySet().stream()
+            .filter(e -> e.getValue().size() > 1)
+            .map(e -> e.getKey())
+            .collect(Collectors.toList());
+    if (!duplicateIDs.isEmpty()) {
+      throw new IllegalStateException("Duplicate IDs found: " + duplicateIDs);
     }
     NodeResolver nodeResolver =
         new CompositeNodeResolver(new LocalNodeResolver(nodes), this.nodeResolver);

--- a/core/src/main/java/org/lionweb/lioncore/java/utils/MetamodelValidator.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/utils/MetamodelValidator.java
@@ -10,7 +10,14 @@ import org.lionweb.lioncore.java.model.impl.M3Node;
 
 public class MetamodelValidator extends Validator<Metamodel> {
 
-  @Override
+    public static void ensureIsValid(Metamodel metamodel) {
+        ValidationResult vr = new MetamodelValidator().validate(metamodel);
+        if (!vr.isSuccessful()) {
+            throw new RuntimeException("Invalid metamodel: " + vr.getIssues());
+        }
+    }
+
+    @Override
   public ValidationResult validate(Metamodel metamodel) {
     // Given metamodels are also valid node trees, we check against errors for node trees
     ValidationResult result = new NodeTreeValidator().validate(metamodel);

--- a/core/src/main/java/org/lionweb/lioncore/java/utils/MetamodelValidator.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/utils/MetamodelValidator.java
@@ -10,14 +10,14 @@ import org.lionweb.lioncore.java.model.impl.M3Node;
 
 public class MetamodelValidator extends Validator<Metamodel> {
 
-    public static void ensureIsValid(Metamodel metamodel) {
-        ValidationResult vr = new MetamodelValidator().validate(metamodel);
-        if (!vr.isSuccessful()) {
-            throw new RuntimeException("Invalid metamodel: " + vr.getIssues());
-        }
+  public static void ensureIsValid(Metamodel metamodel) {
+    ValidationResult vr = new MetamodelValidator().validate(metamodel);
+    if (!vr.isSuccessful()) {
+      throw new RuntimeException("Invalid metamodel: " + vr.getIssues());
     }
+  }
 
-    @Override
+  @Override
   public ValidationResult validate(Metamodel metamodel) {
     // Given metamodels are also valid node trees, we check against errors for node trees
     ValidationResult result = new NodeTreeValidator().validate(metamodel);

--- a/core/src/main/java/org/lionweb/lioncore/java/utils/MetamodelValidator.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/utils/MetamodelValidator.java
@@ -12,7 +12,8 @@ public class MetamodelValidator extends Validator<Metamodel> {
 
   @Override
   public ValidationResult validate(Metamodel metamodel) {
-    ValidationResult result = new ValidationResult();
+    // Given metamodels are also valid node trees, we check against errors for node trees
+    ValidationResult result = new NodeTreeValidator().validate(metamodel);
 
     metamodel
         .thisAndAllDescendants()

--- a/core/src/main/java/org/lionweb/lioncore/java/utils/MetamodelValidator.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/utils/MetamodelValidator.java
@@ -108,7 +108,9 @@ public class MetamodelValidator extends Validator<Metamodel> {
               if (entry.getValue().size() > 1) {
                 entry
                     .getValue()
-                    .forEach((NamespacedEntity el) -> result.addError("Duplicate name", el));
+                    .forEach(
+                        (NamespacedEntity el) ->
+                            result.addError("Duplicate name " + el.getName(), el));
               }
             });
   }

--- a/core/src/main/java/org/lionweb/lioncore/java/utils/NodeTreeValidator.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/utils/NodeTreeValidator.java
@@ -9,7 +9,7 @@ public class NodeTreeValidator extends Validator<Node> {
   public ValidationResult validate(Node element) {
     ValidationResult validationResult = new ValidationResult();
     validateNodeAndDescendants(element, validationResult);
-    validateNodeAndDescendants(element, validationResult);
+    validateIDsAreUnique(element, validationResult);
     return validationResult;
   }
 
@@ -19,17 +19,17 @@ public class NodeTreeValidator extends Validator<Node> {
   }
 
   private void validateIDsAreUnique(Node node, ValidationResult result) {
-    Map<String, String> uniqueIDs = new HashMap<>();
+    Map<String, Node> uniqueIDs = new HashMap<>();
     node.thisAndAllDescendants()
         .forEach(
             n -> {
-              String id = node.getID();
+              String id = n.getID();
               if (id != null) {
                 if (uniqueIDs.containsKey(id)) {
                   result.addError(
                       "ID " + id + " is duplicate. It is also used by " + uniqueIDs.get(id), n);
                 } else {
-                  uniqueIDs.put(id, n.getID());
+                  uniqueIDs.put(id, n);
                 }
               }
             });

--- a/core/src/main/java/org/lionweb/lioncore/java/utils/NodeTreeValidator.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/utils/NodeTreeValidator.java
@@ -1,5 +1,7 @@
 package org.lionweb.lioncore.java.utils;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.lionweb.lioncore.java.model.Node;
 
 public class NodeTreeValidator extends Validator<Node> {
@@ -7,11 +9,29 @@ public class NodeTreeValidator extends Validator<Node> {
   public ValidationResult validate(Node element) {
     ValidationResult validationResult = new ValidationResult();
     validateNodeAndDescendants(element, validationResult);
+    validateNodeAndDescendants(element, validationResult);
     return validationResult;
   }
 
   private void validateNodeAndDescendants(Node node, ValidationResult validationResult) {
     validationResult.checkForError(!CommonChecks.isValidID(node.getID()), "Invalid ID", node);
     node.getChildren().forEach(child -> validateNodeAndDescendants(child, validationResult));
+  }
+
+  private void validateIDsAreUnique(Node node, ValidationResult result) {
+    Map<String, String> uniqueIDs = new HashMap<>();
+    node.thisAndAllDescendants()
+        .forEach(
+            n -> {
+              String id = node.getID();
+              if (id != null) {
+                if (uniqueIDs.containsKey(id)) {
+                  result.addError(
+                      "ID " + id + " is duplicate. It is also used by " + uniqueIDs.get(id), n);
+                } else {
+                  uniqueIDs.put(id, n.getID());
+                }
+              }
+            });
   }
 }

--- a/core/src/main/java/org/lionweb/lioncore/java/utils/ValidationResult.java
+++ b/core/src/main/java/org/lionweb/lioncore/java/utils/ValidationResult.java
@@ -2,6 +2,7 @@ package org.lionweb.lioncore.java.utils;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class ValidationResult {
   private final Set<Issue> issues = new HashSet<>();
@@ -24,5 +25,12 @@ public class ValidationResult {
       issues.add(new Issue(IssueSeverity.Error, message, subject));
     }
     return this;
+  }
+
+  @Override
+  public String toString() {
+    return "ValidationResult("
+        + issues.stream().map(Issue::toString).collect(Collectors.joining(", "))
+        + ")";
   }
 }

--- a/core/src/test/java/org/lionweb/lioncore/java/metamodel/LionCoreBuiltinsTest.java
+++ b/core/src/test/java/org/lionweb/lioncore/java/metamodel/LionCoreBuiltinsTest.java
@@ -3,6 +3,8 @@ package org.lionweb.lioncore.java.metamodel;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
+import org.lionweb.lioncore.java.utils.MetamodelValidator;
+import org.lionweb.lioncore.java.utils.ValidationResult;
 
 public class LionCoreBuiltinsTest {
 
@@ -20,5 +22,13 @@ public class LionCoreBuiltinsTest {
     assertEquals("LIonCore_M3_Boolean", LionCoreBuiltins.getBoolean().getID());
     assertEquals("LIonCore_M3_Integer", LionCoreBuiltins.getInteger().getID());
     assertEquals("LIonCore_M3_JSON", LionCoreBuiltins.getJSON().getID());
+  }
+
+  @Test
+  public void lionCoreBuiltinsIsValid() {
+    ValidationResult vr = new MetamodelValidator().validate(LionCoreBuiltins.getInstance());
+    if (!vr.isSuccessful()) {
+      throw new RuntimeException("LionCoreBuiltins Metamodel is not valid: " + vr);
+    }
   }
 }

--- a/core/src/test/java/org/lionweb/lioncore/java/self/LionCoreTest.java
+++ b/core/src/test/java/org/lionweb/lioncore/java/self/LionCoreTest.java
@@ -1,0 +1,16 @@
+package org.lionweb.lioncore.java.self;
+
+import org.junit.Test;
+import org.lionweb.lioncore.java.utils.MetamodelValidator;
+import org.lionweb.lioncore.java.utils.ValidationResult;
+
+public class LionCoreTest {
+
+  @Test
+  public void lionCoreIsValid() {
+    ValidationResult vr = new MetamodelValidator().validate(LionCore.getInstance());
+    if (!vr.isSuccessful()) {
+      throw new RuntimeException("LionCore Metamodel is not valid: " + vr);
+    }
+  }
+}

--- a/core/src/test/java/org/lionweb/lioncore/java/serialization/JsonSerializationTest.java
+++ b/core/src/test/java/org/lionweb/lioncore/java/serialization/JsonSerializationTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.assertEquals;
 import static org.lionweb.lioncore.java.serialization.SerializedJsonComparisonUtils.assertEquivalentLionWebJson;
 
 import com.google.gson.*;
+
+import java.io.FileReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Arrays;
@@ -147,5 +149,13 @@ public class JsonSerializationTest extends SerializationTest {
     assertEquals(false, sideTransformInfo.isAbstract());
     assertEquals(3, sideTransformInfo.getFeatures().size());
     assertEquals(3, sideTransformInfo.getChildren().size());
+  }
+
+  @Test
+  public void unserializeMetamodelWithDependencies() {
+    JsonSerialization jsonSerialization = JsonSerialization.getStandardSerialization();
+    Metamodel starlasu = (Metamodel) jsonSerialization.unserializeToNodes(this.getClass().getResourceAsStream("/properties-example/starlasu.lmm.json")).get(0);
+    jsonSerialization.getNodeResolver().addTree(starlasu);
+    Metamodel properties = (Metamodel) jsonSerialization.unserializeToNodes(this.getClass().getResourceAsStream("/properties-example/properties.lmm.json")).get(0);
   }
 }

--- a/core/src/test/java/org/lionweb/lioncore/java/serialization/JsonSerializationTest.java
+++ b/core/src/test/java/org/lionweb/lioncore/java/serialization/JsonSerializationTest.java
@@ -4,8 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.lionweb.lioncore.java.serialization.SerializedJsonComparisonUtils.assertEquivalentLionWebJson;
 
 import com.google.gson.*;
-
-import java.io.FileReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Arrays;
@@ -154,8 +152,18 @@ public class JsonSerializationTest extends SerializationTest {
   @Test
   public void unserializeMetamodelWithDependencies() {
     JsonSerialization jsonSerialization = JsonSerialization.getStandardSerialization();
-    Metamodel starlasu = (Metamodel) jsonSerialization.unserializeToNodes(this.getClass().getResourceAsStream("/properties-example/starlasu.lmm.json")).get(0);
+    Metamodel starlasu =
+        (Metamodel)
+            jsonSerialization
+                .unserializeToNodes(
+                    this.getClass().getResourceAsStream("/properties-example/starlasu.lmm.json"))
+                .get(0);
     jsonSerialization.getNodeResolver().addTree(starlasu);
-    Metamodel properties = (Metamodel) jsonSerialization.unserializeToNodes(this.getClass().getResourceAsStream("/properties-example/properties.lmm.json")).get(0);
+    Metamodel properties =
+        (Metamodel)
+            jsonSerialization
+                .unserializeToNodes(
+                    this.getClass().getResourceAsStream("/properties-example/properties.lmm.json"))
+                .get(0);
   }
 }

--- a/core/src/test/java/org/lionweb/lioncore/java/serialization/JsonSerializationTest.java
+++ b/core/src/test/java/org/lionweb/lioncore/java/serialization/JsonSerializationTest.java
@@ -13,6 +13,7 @@ import org.lionweb.lioncore.java.metamodel.*;
 import org.lionweb.lioncore.java.model.Node;
 import org.lionweb.lioncore.java.model.ReferenceValue;
 import org.lionweb.lioncore.java.model.impl.DynamicNode;
+import org.lionweb.lioncore.java.utils.MetamodelValidator;
 
 /** Testing various functionalities of JsonSerialization. */
 public class JsonSerializationTest extends SerializationTest {
@@ -165,5 +166,7 @@ public class JsonSerializationTest extends SerializationTest {
                 .unserializeToNodes(
                     this.getClass().getResourceAsStream("/properties-example/properties.lmm.json"))
                 .get(0);
+    MetamodelValidator.ensureIsValid(starlasu);
+    MetamodelValidator.ensureIsValid(properties);
   }
 }

--- a/core/src/test/java/org/lionweb/lioncore/java/serialization/SerializationOfLibraryTest.java
+++ b/core/src/test/java/org/lionweb/lioncore/java/serialization/SerializationOfLibraryTest.java
@@ -89,4 +89,12 @@ public class SerializationOfLibraryTest extends SerializationTest {
         JsonParser.parseReader(new InputStreamReader(inputStream)).getAsJsonObject();
     assertEquivalentLionWebJson(jsonRead, jsonSerialized);
   }
+
+  @Test(expected = IllegalStateException.class)
+  public void unserializeMetamodelWithDuplicateIDs() {
+    InputStream inputStream =
+        this.getClass().getResourceAsStream("/serialization/library-metamodel-with-duplicate.json");
+    JsonSerialization jsonSerialization = JsonSerialization.getStandardSerialization();
+    jsonSerialization.unserializeToNodes(inputStream);
+  }
 }

--- a/core/src/test/resources/properties-example/properties.lmm.json
+++ b/core/src/test/resources/properties-example/properties.lmm.json
@@ -1,0 +1,1104 @@
+{
+  "serializationFormatVersion": "1",
+  "metamodels": [],
+  "nodes": [
+    {
+      "id": "io_lionweb_Properties",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "Metamodel"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "Metamodel_name"
+          },
+          "value": "io.lionweb.Properties"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "version"
+          },
+          "value": "1"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "key"
+          },
+          "value": "io_lionweb_Properties"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "elements"
+          },
+          "children": [
+            "io_lionweb_Properties-PropertiesFile",
+            "io_lionweb_Properties-Property",
+            "io_lionweb_Properties-Value",
+            "io_lionweb_Properties-BooleanValue",
+            "io_lionweb_Properties-DecValue",
+            "io_lionweb_Properties-IntValue",
+            "io_lionweb_Properties-StringValue"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "dependsOn"
+          },
+          "targets": [
+            {
+              "resolveInfo": "com.strumenta.StarLasu",
+              "reference": "com_strumenta_StarLasu"
+            }
+          ]
+        }
+      ],
+      "parent": null
+    },
+    {
+      "id": "io_lionweb_Properties-PropertiesFile",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "NamespacedEntity_name"
+          },
+          "value": "PropertiesFile"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "qualifiedName"
+          },
+          "value": "io.lionweb.Properties.PropertiesFile"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "key"
+          },
+          "value": "io_lionweb_Properties-PropertiesFile"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "features"
+          },
+          "children": [
+            "props"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "Concept_extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "ASTNode",
+              "reference": "StarLasu-ASTNode"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "implements"
+          },
+          "targets": []
+        }
+      ],
+      "parent": "io_lionweb_Properties"
+    },
+    {
+      "id": "props",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "Containment"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "multiple"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "NamespacedEntity_name"
+          },
+          "value": "props"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "qualifiedName"
+          },
+          "value": "io.lionweb.Properties.PropertiesFile.props"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "key"
+          },
+          "value": "io_lionweb_Properties-PropertiesFile-props"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "Link_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Property",
+              "reference": "io_lionweb_Properties-Property"
+            }
+          ]
+        }
+      ],
+      "parent": "io_lionweb_Properties-PropertiesFile"
+    },
+    {
+      "id": "io_lionweb_Properties-Property",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "NamespacedEntity_name"
+          },
+          "value": "Property"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "qualifiedName"
+          },
+          "value": "io.lionweb.Properties.Property"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "key"
+          },
+          "value": "io_lionweb_Properties-Property"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "features"
+          },
+          "children": [
+            "name",
+            "value"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "Concept_extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "ASTNode",
+              "reference": "StarLasu-ASTNode"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "implements"
+          },
+          "targets": []
+        }
+      ],
+      "parent": "io_lionweb_Properties"
+    },
+    {
+      "id": "name",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "NamespacedEntity_name"
+          },
+          "value": "name"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "qualifiedName"
+          },
+          "value": "io.lionweb.Properties.Property.name"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "key"
+          },
+          "value": "io_lionweb_Properties-Property-name"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "Property_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LIonCore_M3_String"
+            }
+          ]
+        }
+      ],
+      "parent": "io_lionweb_Properties-Property"
+    },
+    {
+      "id": "value",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "Containment"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "multiple"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "NamespacedEntity_name"
+          },
+          "value": "value"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "qualifiedName"
+          },
+          "value": "io.lionweb.Properties.Property.value"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "key"
+          },
+          "value": "io_lionweb_Properties-Property-value"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "Link_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Value",
+              "reference": "io_lionweb_Properties-Value"
+            }
+          ]
+        }
+      ],
+      "parent": "io_lionweb_Properties-Property"
+    },
+    {
+      "id": "io_lionweb_Properties-Value",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "NamespacedEntity_name"
+          },
+          "value": "Value"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "qualifiedName"
+          },
+          "value": "io.lionweb.Properties.Value"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "key"
+          },
+          "value": "io_lionweb_Properties-Value"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "Concept_extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "ASTNode",
+              "reference": "StarLasu-ASTNode"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "implements"
+          },
+          "targets": []
+        }
+      ],
+      "parent": "io_lionweb_Properties"
+    },
+    {
+      "id": "io_lionweb_Properties-BooleanValue",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "NamespacedEntity_name"
+          },
+          "value": "BooleanValue"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "qualifiedName"
+          },
+          "value": "io.lionweb.Properties.BooleanValue"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "key"
+          },
+          "value": "io_lionweb_Properties-BooleanValue"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "features"
+          },
+          "children": [
+            "value"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "Concept_extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Value",
+              "reference": "io_lionweb_Properties-Value"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "implements"
+          },
+          "targets": []
+        }
+      ],
+      "parent": "io_lionweb_Properties"
+    },
+    {
+      "id": "value",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "NamespacedEntity_name"
+          },
+          "value": "value"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "qualifiedName"
+          },
+          "value": "io.lionweb.Properties.BooleanValue.value"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "key"
+          },
+          "value": "io_lionweb_Properties-BooleanValue-value"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "Property_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Boolean",
+              "reference": "LIonCore_M3_Boolean"
+            }
+          ]
+        }
+      ],
+      "parent": "io_lionweb_Properties-BooleanValue"
+    },
+    {
+      "id": "io_lionweb_Properties-DecValue",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "NamespacedEntity_name"
+          },
+          "value": "DecValue"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "qualifiedName"
+          },
+          "value": "io.lionweb.Properties.DecValue"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "key"
+          },
+          "value": "io_lionweb_Properties-DecValue"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "features"
+          },
+          "children": [
+            "value"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "Concept_extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Value",
+              "reference": "io_lionweb_Properties-Value"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "implements"
+          },
+          "targets": []
+        }
+      ],
+      "parent": "io_lionweb_Properties"
+    },
+    {
+      "id": "value",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "NamespacedEntity_name"
+          },
+          "value": "value"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "qualifiedName"
+          },
+          "value": "io.lionweb.Properties.DecValue.value"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "key"
+          },
+          "value": "io_lionweb_Properties-DecValue-value"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "Property_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LIonCore_M3_String"
+            }
+          ]
+        }
+      ],
+      "parent": "io_lionweb_Properties-DecValue"
+    },
+    {
+      "id": "io_lionweb_Properties-IntValue",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "NamespacedEntity_name"
+          },
+          "value": "IntValue"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "qualifiedName"
+          },
+          "value": "io.lionweb.Properties.IntValue"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "key"
+          },
+          "value": "io_lionweb_Properties-IntValue"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "features"
+          },
+          "children": [
+            "value"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "Concept_extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Value",
+              "reference": "io_lionweb_Properties-Value"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "implements"
+          },
+          "targets": []
+        }
+      ],
+      "parent": "io_lionweb_Properties"
+    },
+    {
+      "id": "value",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "NamespacedEntity_name"
+          },
+          "value": "value"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "qualifiedName"
+          },
+          "value": "io.lionweb.Properties.IntValue.value"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "key"
+          },
+          "value": "io_lionweb_Properties-IntValue-value"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "Property_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LIonCore_M3_String"
+            }
+          ]
+        }
+      ],
+      "parent": "io_lionweb_Properties-IntValue"
+    },
+    {
+      "id": "io_lionweb_Properties-StringValue",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "NamespacedEntity_name"
+          },
+          "value": "StringValue"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "qualifiedName"
+          },
+          "value": "io.lionweb.Properties.StringValue"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "key"
+          },
+          "value": "io_lionweb_Properties-StringValue"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "features"
+          },
+          "children": [
+            "value"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "Concept_extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Value",
+              "reference": "io_lionweb_Properties-Value"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "implements"
+          },
+          "targets": []
+        }
+      ],
+      "parent": "io_lionweb_Properties"
+    },
+    {
+      "id": "value",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "NamespacedEntity_name"
+          },
+          "value": "value"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "qualifiedName"
+          },
+          "value": "io.lionweb.Properties.StringValue.value"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "key"
+          },
+          "value": "io_lionweb_Properties-StringValue-value"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "Property_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LIonCore_M3_String"
+            }
+          ]
+        }
+      ],
+      "parent": "io_lionweb_Properties-StringValue"
+    }
+  ]
+}

--- a/core/src/test/resources/properties-example/properties.lmm.json
+++ b/core/src/test/resources/properties-example/properties.lmm.json
@@ -119,7 +119,7 @@
             "key": "features"
           },
           "children": [
-            "props"
+            "io_lionweb_Properties-PropertiesFile-props"
           ]
         }
       ],
@@ -149,7 +149,7 @@
       "parent": "io_lionweb_Properties"
     },
     {
-      "id": "props",
+      "id": "io_lionweb_Properties-PropertiesFile-props",
       "concept": {
         "metamodel": "LIonCore_M3",
         "version": "1",
@@ -272,8 +272,8 @@
             "key": "features"
           },
           "children": [
-            "name",
-            "value"
+            "io_lionweb_Properties-Property-name",
+            "io_lionweb_Properties-Property-value"
           ]
         }
       ],
@@ -303,7 +303,7 @@
       "parent": "io_lionweb_Properties"
     },
     {
-      "id": "name",
+      "id": "io_lionweb_Properties-Property-name",
       "concept": {
         "metamodel": "LIonCore_M3",
         "version": "1",
@@ -370,7 +370,7 @@
       "parent": "io_lionweb_Properties-Property"
     },
     {
-      "id": "value",
+      "id": "io_lionweb_Properties-Property-value",
       "concept": {
         "metamodel": "LIonCore_M3",
         "version": "1",
@@ -569,7 +569,7 @@
             "key": "features"
           },
           "children": [
-            "value"
+            "io_lionweb_Properties-BooleanValue-value"
           ]
         }
       ],
@@ -599,7 +599,7 @@
       "parent": "io_lionweb_Properties"
     },
     {
-      "id": "value",
+      "id": "io_lionweb_Properties-BooleanValue-value",
       "concept": {
         "metamodel": "LIonCore_M3",
         "version": "1",
@@ -714,7 +714,7 @@
             "key": "features"
           },
           "children": [
-            "value"
+            "io_lionweb_Properties-DecValue-value"
           ]
         }
       ],
@@ -744,7 +744,7 @@
       "parent": "io_lionweb_Properties"
     },
     {
-      "id": "value",
+      "id": "io_lionweb_Properties-DecValue-value",
       "concept": {
         "metamodel": "LIonCore_M3",
         "version": "1",
@@ -859,7 +859,7 @@
             "key": "features"
           },
           "children": [
-            "value"
+            "io_lionweb_Properties-IntValue-value"
           ]
         }
       ],
@@ -889,7 +889,7 @@
       "parent": "io_lionweb_Properties"
     },
     {
-      "id": "value",
+      "id": "io_lionweb_Properties-IntValue-value",
       "concept": {
         "metamodel": "LIonCore_M3",
         "version": "1",
@@ -1004,7 +1004,7 @@
             "key": "features"
           },
           "children": [
-            "value"
+            "io_lionweb_Properties-StringValue-value"
           ]
         }
       ],
@@ -1034,7 +1034,7 @@
       "parent": "io_lionweb_Properties"
     },
     {
-      "id": "value",
+      "id": "io_lionweb_Properties-StringValue-value",
       "concept": {
         "metamodel": "LIonCore_M3",
         "version": "1",

--- a/core/src/test/resources/properties-example/starlasu.lmm.json
+++ b/core/src/test/resources/properties-example/starlasu.lmm.json
@@ -1,0 +1,468 @@
+{
+  "serializationFormatVersion": "1",
+  "metamodels": [],
+  "nodes": [
+    {
+      "id": "com_strumenta_StarLasu",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "Metamodel"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "Metamodel_name"
+          },
+          "value": "com.strumenta.StarLasu"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "version"
+          },
+          "value": "1"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "key"
+          },
+          "value": "com_strumenta_StarLasu"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "elements"
+          },
+          "children": [
+            "StarLasu-ASTNode",
+            "StarLasu-GenericErrorNode",
+            "StarLasu-Named",
+            "StarLasu-PossiblyNamed",
+            "StarLasu-Position",
+            "StarLasu-Char"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "dependsOn"
+          },
+          "targets": []
+        }
+      ],
+      "parent": null
+    },
+    {
+      "id": "StarLasu-ASTNode",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "NamespacedEntity_name"
+          },
+          "value": "ASTNode"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "qualifiedName"
+          },
+          "value": "com.strumenta.StarLasu.ASTNode"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "key"
+          },
+          "value": "StarLasu-ASTNode"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "Concept_extends"
+          },
+          "targets": []
+        },
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "implements"
+          },
+          "targets": []
+        }
+      ],
+      "parent": "com_strumenta_StarLasu"
+    },
+    {
+      "id": "StarLasu-GenericErrorNode",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "NamespacedEntity_name"
+          },
+          "value": "GenericErrorNode"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "qualifiedName"
+          },
+          "value": "com.strumenta.StarLasu.GenericErrorNode"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "key"
+          },
+          "value": "StarLasu-GenericErrorNode"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "Concept_extends"
+          },
+          "targets": []
+        },
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "implements"
+          },
+          "targets": []
+        }
+      ],
+      "parent": "com_strumenta_StarLasu"
+    },
+    {
+      "id": "StarLasu-Named",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "ConceptInterface"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "NamespacedEntity_name"
+          },
+          "value": "Named"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "qualifiedName"
+          },
+          "value": "com.strumenta.StarLasu.Named"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "key"
+          },
+          "value": "StarLasu-Named"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "ConceptInterface_extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "PossiblyNamed",
+              "reference": "StarLasu-PossiblyNamed"
+            }
+          ]
+        }
+      ],
+      "parent": "com_strumenta_StarLasu"
+    },
+    {
+      "id": "StarLasu-PossiblyNamed",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "ConceptInterface"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "NamespacedEntity_name"
+          },
+          "value": "PossiblyNamed"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "qualifiedName"
+          },
+          "value": "com.strumenta.StarLasu.PossiblyNamed"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "key"
+          },
+          "value": "StarLasu-PossiblyNamed"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "features"
+          },
+          "children": [
+            "StarLasu-PossiblyNamed-name"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "ConceptInterface_extends"
+          },
+          "targets": []
+        }
+      ],
+      "parent": "com_strumenta_StarLasu"
+    },
+    {
+      "id": "StarLasu-PossiblyNamed-name",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "NamespacedEntity_name"
+          },
+          "value": "name"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "qualifiedName"
+          },
+          "value": "com.strumenta.StarLasu.PossiblyNamed.name"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "key"
+          },
+          "value": "StarLasu-PossiblyNamed-name"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "Property_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LIonCore_M3_String"
+            }
+          ]
+        }
+      ],
+      "parent": "StarLasu-PossiblyNamed"
+    },
+    {
+      "id": "StarLasu-Position",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "PrimitiveType"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "NamespacedEntity_name"
+          },
+          "value": "Position"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "qualifiedName"
+          },
+          "value": "com.strumenta.StarLasu.Position"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "key"
+          },
+          "value": "StarLasu-Position"
+        }
+      ],
+      "children": [],
+      "references": [],
+      "parent": "com_strumenta_StarLasu"
+    },
+    {
+      "id": "StarLasu-Char",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "PrimitiveType"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "NamespacedEntity_name"
+          },
+          "value": "Char"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "qualifiedName"
+          },
+          "value": "com.strumenta.StarLasu.Char"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "key"
+          },
+          "value": "StarLasu-Char"
+        }
+      ],
+      "children": [],
+      "references": [],
+      "parent": "com_strumenta_StarLasu"
+    }
+  ]
+}

--- a/core/src/test/resources/serialization/library-metamodel-with-duplicate.json
+++ b/core/src/test/resources/serialization/library-metamodel-with-duplicate.json
@@ -113,7 +113,6 @@
           },
           "children": [
             "library-Book-title",
-            "library-Book-pages",
             "library-Book-author"
           ]
         }
@@ -206,7 +205,7 @@
       "parent": "library-Book"
     },
     {
-      "id": "library-Book-pages",
+      "id": "library-Book-title",
       "concept": {
         "metamodel": "LIonCore_M3",
         "version": "1",
@@ -251,7 +250,7 @@
             "version": "1",
             "key": "key"
           },
-          "value": "library-Book-pages"
+          "value": "library-Book-title"
         }
       ],
       "children": [],

--- a/core/src/test/resources/serialization/library-metamodel-with-duplicate.json
+++ b/core/src/test/resources/serialization/library-metamodel-with-duplicate.json
@@ -1,0 +1,997 @@
+{
+  "serializationFormatVersion": "1",
+  "metamodels": [],
+  "nodes": [
+    {
+      "id": "library",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "Metamodel"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "Metamodel_name"
+          },
+          "value": "library"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "version"
+          },
+          "value": "1"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "key"
+          },
+          "value": "library"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "elements"
+          },
+          "children": [
+            "library-Book",
+            "library-Library",
+            "library-Writer",
+            "library-GuideBookWriter",
+            "library-SpecialistBookWriter"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "dependsOn"
+          },
+          "targets": []
+        }
+      ],
+      "parent": null
+    },
+    {
+      "id": "library-Book",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "NamespacedEntity_name"
+          },
+          "value": "Book"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "qualifiedName"
+          },
+          "value": "library.Book"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "key"
+          },
+          "value": "library-Book"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "features"
+          },
+          "children": [
+            "library-Book-title",
+            "library-Book-pages",
+            "library-Book-author"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "Concept_extends"
+          },
+          "targets": []
+        },
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "implements"
+          },
+          "targets": []
+        }
+      ],
+      "parent": "library"
+    },
+    {
+      "id": "library-Book-title",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "NamespacedEntity_name"
+          },
+          "value": "title"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "qualifiedName"
+          },
+          "value": "library.Book.title"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "key"
+          },
+          "value": "library-Book-title"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "Property_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LIonCore_M3_String"
+            }
+          ]
+        }
+      ],
+      "parent": "library-Book"
+    },
+    {
+      "id": "library-Book-pages",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "NamespacedEntity_name"
+          },
+          "value": "pages"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "qualifiedName"
+          },
+          "value": "library.Book.pages"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "key"
+          },
+          "value": "library-Book-pages"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "Property_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Integer",
+              "reference": "LIonCore_M3_Integer"
+            }
+          ]
+        }
+      ],
+      "parent": "library-Book"
+    },
+    {
+      "id": "library-Book-author",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "Reference"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "multiple"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "NamespacedEntity_name"
+          },
+          "value": "author"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "qualifiedName"
+          },
+          "value": "library.Book.author"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "key"
+          },
+          "value": "library-Book-author"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "Link_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Writer",
+              "reference": "library-Writer"
+            }
+          ]
+        }
+      ],
+      "parent": "library-Book"
+    },
+    {
+      "id": "library-Library",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "NamespacedEntity_name"
+          },
+          "value": "Library"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "qualifiedName"
+          },
+          "value": "library.Library"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "key"
+          },
+          "value": "library-Library"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "features"
+          },
+          "children": [
+            "library-Library-name",
+            "library-Library-books"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "Concept_extends"
+          },
+          "targets": []
+        },
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "implements"
+          },
+          "targets": []
+        }
+      ],
+      "parent": "library"
+    },
+    {
+      "id": "library-Library-name",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "NamespacedEntity_name"
+          },
+          "value": "name"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "qualifiedName"
+          },
+          "value": "library.Library.name"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "key"
+          },
+          "value": "library-Library-name"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "Property_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LIonCore_M3_String"
+            }
+          ]
+        }
+      ],
+      "parent": "library-Library"
+    },
+    {
+      "id": "library-Library-books",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "Containment"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "multiple"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "NamespacedEntity_name"
+          },
+          "value": "books"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "qualifiedName"
+          },
+          "value": "library.Library.books"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "key"
+          },
+          "value": "library-Library-books"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "Link_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Book",
+              "reference": "library-Book"
+            }
+          ]
+        }
+      ],
+      "parent": "library-Library"
+    },
+    {
+      "id": "library-Writer",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "NamespacedEntity_name"
+          },
+          "value": "Writer"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "qualifiedName"
+          },
+          "value": "library.Writer"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "key"
+          },
+          "value": "library-Writer"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "features"
+          },
+          "children": [
+            "library-Writer-name"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "Concept_extends"
+          },
+          "targets": []
+        },
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "implements"
+          },
+          "targets": []
+        }
+      ],
+      "parent": "library"
+    },
+    {
+      "id": "library-Writer-name",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "NamespacedEntity_name"
+          },
+          "value": "name"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "qualifiedName"
+          },
+          "value": "library.Writer.name"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "key"
+          },
+          "value": "library-Writer-name"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "Property_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LIonCore_M3_String"
+            }
+          ]
+        }
+      ],
+      "parent": "library-Writer"
+    },
+    {
+      "id": "library-GuideBookWriter",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "NamespacedEntity_name"
+          },
+          "value": "GuideBookWriter"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "qualifiedName"
+          },
+          "value": "library.GuideBookWriter"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "key"
+          },
+          "value": "library-GuideBookWriter"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "features"
+          },
+          "children": [
+            "library-GuideBookWriter-countries"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "Concept_extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Writer",
+              "reference": "library-Writer"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "implements"
+          },
+          "targets": []
+        }
+      ],
+      "parent": "library"
+    },
+    {
+      "id": "library-GuideBookWriter-countries",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "NamespacedEntity_name"
+          },
+          "value": "countries"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "qualifiedName"
+          },
+          "value": "library.GuideBookWriter.countries"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "key"
+          },
+          "value": "library-GuideBookWriter-countries"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "Property_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LIonCore_M3_String"
+            }
+          ]
+        }
+      ],
+      "parent": "library-GuideBookWriter"
+    },
+    {
+      "id": "library-SpecialistBookWriter",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "NamespacedEntity_name"
+          },
+          "value": "SpecialistBookWriter"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "qualifiedName"
+          },
+          "value": "library.SpecialistBookWriter"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "key"
+          },
+          "value": "library-SpecialistBookWriter"
+        }
+      ],
+      "children": [
+        {
+          "containment": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "features"
+          },
+          "children": [
+            "library-SpecialistBookWriter-subject"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "Concept_extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Writer",
+              "reference": "library-Writer"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "implements"
+          },
+          "targets": []
+        }
+      ],
+      "parent": "library"
+    },
+    {
+      "id": "library-SpecialistBookWriter-subject",
+      "concept": {
+        "metamodel": "LIonCore_M3",
+        "version": "1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "derived"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "NamespacedEntity_name"
+          },
+          "value": "subject"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "qualifiedName"
+          },
+          "value": "library.SpecialistBookWriter.subject"
+        },
+        {
+          "property": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "key"
+          },
+          "value": "library-SpecialistBookWriter-subject"
+        }
+      ],
+      "children": [],
+      "references": [
+        {
+          "reference": {
+            "metamodel": "LIonCore_M3",
+            "version": "1",
+            "key": "Property_type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LIonCore_M3_String"
+            }
+          ]
+        }
+      ],
+      "parent": "library-SpecialistBookWriter"
+    }
+  ]
+}


### PR DESCRIPTION
This should solve https://github.com/LIonWeb-org/mps-meetup-2023/issues/4

This is built on top of #60 

The test added provided also an example

@enikao please not that I have regenerated the metamodels used in tests w.r.t. the versions I sent you (which have duplicate Node IDs!)